### PR TITLE
fix(core): address Codex audit P1 × 2 + P2 findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --all --all-features
 
   # ─── Clippy ───────────────────────────────────────────────────────────────
 
@@ -47,7 +47,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all --all-features -- -D warnings
 
   # ─── Formatting ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes all three issues raised in the Codex audit review.

- **[P1] Non-atomic vector write** — `assert_fact_with_embedding` previously committed to redb *before* inserting into the vector index. A panic in the vector insert (empty embedding or dimension mismatch) left a fact in storage with no vector, impossible to detect without a full scan. Fixed by pre-validating the embedding and returning `KronroeError::InvalidEmbedding` before touching redb.

- **[P1] `debug_assert_eq!` in `cosine_similarity`** — this assertion is a no-op in `--release` builds. `zip` silently truncates to the shorter slice on dimension mismatch, producing wrong cosine scores that surface as subtle mis-ranking in production. Replaced with a runtime length guard (`if a.len() != b.len() { return 0.0; }`).

- **[P2] CI missing `--all-features` coverage** — `cargo test --all` and `cargo clippy --all` ran without `--all-features`, leaving the `vector` and `fulltext` feature-gated paths untested in CI. Both steps now include `--all-features`.

## Files changed

| File | Change |
|------|--------|
| `crates/core/src/lib.rs` | Add `KronroeError::InvalidEmbedding`; pre-validate in `assert_fact_with_embedding` |
| `crates/core/src/vector.rs` | Replace `debug_assert_eq!` with runtime guard; add `pub(crate) dim()` getter |
| `.github/workflows/ci.yml` | Add `--all-features` to test + clippy steps |

## Test plan

- [x] `cargo test --all --all-features` — 40 tests, all pass
- [x] `cargo clippy --all --all-features -- -D warnings` — clean, no warnings
- [x] `cargo fmt --all -- --check` — no formatting changes needed
- [x] Existing vector tests (`test_insert_empty_embedding_panics`, `test_insert_dimension_mismatch_panics`) still pass — `VectorIndex::insert` still panics as documented, but callers going through the public API get a proper `Result` instead
