### PR TITLE
fix(security): harden CSP, HTTP headers, and PR-gate site build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,41 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  # ─── Site build ───────────────────────────────────────────────────────────────
+
+  site-build:
+    name: Site Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM package
+        run: wasm-pack build crates/wasm --target web --out-dir ../../site/public/pkg --no-typescript
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install site dependencies
+        run: npm ci
+        working-directory: site
+
+      - name: Build site
+        run: npm run build
+        working-directory: site

--- a/firebase.json
+++ b/firebase.json
@@ -4,6 +4,14 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          { "key": "X-Frame-Options",           "value": "DENY" },
+          { "key": "X-Content-Type-Options",    "value": "nosniff" },
+          { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" }
+        ]
+      },
+      {
         "source": "**/*.@(js|css|wasm)",
         "headers": [
           {

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Kronroe — embedded temporal property graph database. Try it live in your browser." />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self';" />
     <title>Kronroe — Temporal Graph Playground</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Addresses three findings from the Codex audit.

## Changes

**`site/index.html`**
- Add `'wasm-unsafe-eval'` to `script-src` — protects the wasm-pack fallback path (`WebAssembly.instantiate` from buffer) when streaming instantiation isn't available
- Remove `frame-ancestors` from meta CSP — the spec excludes it from meta elements; it was silently ignored by all browsers

**`firebase.json`**
- Add `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` HTTP response headers on all routes via a new `**` rule
- Firebase merges headers from all matching rules, so Cache-Control rules are unaffected

**`.github/workflows/ci.yml`**
- Add `Site Build` job: wasm-pack → Vite build on every PR so a broken playground build can't merge silently
- Mirrors `deploy-site.yml` exactly minus the Firebase deploy step