### PR TITLE
Add privacy controls and trust layer

### DIFF
--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -93,6 +93,7 @@
           <a href="/community/">Community</a>
           <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>

--- a/site/commercial/index.html
+++ b/site/commercial/index.html
@@ -248,6 +248,7 @@
           <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
           <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>

--- a/site/community/index.html
+++ b/site/community/index.html
@@ -108,6 +108,7 @@
           <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
           <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -140,6 +140,7 @@
           <a href="/community/">Community</a>
           <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
       </div>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -114,6 +114,7 @@
           <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
           <a href="/community/">Community</a>
           <a href="/about/">About</a>
+          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -2,20 +2,36 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Google tag (gtag.js) — deferred until after first paint -->
+    <!-- Optional analytics — only load after explicit consent -->
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      window.__kronroeAnalyticsKey = 'kronroe-analytics-consent';
       window.__kronroePageViewSent = false;
+      window.__kronroeAnalyticsLoaded = false;
+      function getAnalyticsConsent() {
+        try {
+          return window.localStorage.getItem(window.__kronroeAnalyticsKey) || 'unset';
+        } catch (_) {
+          return 'unset';
+        }
+      }
+      function setAnalyticsConsent(value) {
+        try {
+          window.localStorage.setItem(window.__kronroeAnalyticsKey, value);
+        } catch (_) {}
+      }
       function sendPageViewOnce() {
-        if (window.__kronroePageViewSent) return;
+        if (window.__kronroePageViewSent || !window.__kronroeAnalyticsLoaded) return;
         window.__kronroePageViewSent = true;
         gtag('event', 'page_view', {
           page_location: window.location.href,
           page_title: document.title,
         });
       }
-      (window.requestIdleCallback || setTimeout)(function(){
+      function loadAnalytics() {
+        if (window.__kronroeAnalyticsLoaded || getAnalyticsConsent() !== 'accepted') return;
+        window.__kronroeAnalyticsLoaded = true;
         var s = document.createElement('script');
         s.src = 'https://www.googletagmanager.com/gtag/js?id=G-QC2EK11KHY';
         s.async = true;
@@ -25,10 +41,25 @@
           sendPageViewOnce();
         };
         document.head.appendChild(s);
-      });
+      }
+      window.kronroeAnalytics = {
+        getState: getAnalyticsConsent,
+        accept: function () {
+          setAnalyticsConsent('accepted');
+          loadAnalytics();
+          return 'accepted';
+        },
+        decline: function () {
+          setAnalyticsConsent('declined');
+          return 'declined';
+        }
+      };
+      if (getAnalyticsConsent() === 'accepted') {
+        (window.requestIdleCallback || setTimeout)(loadAnalytics);
+      }
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Private, bi-temporal AI memory with hybrid search and eleven MCP tools. Runs on-device across Rust, iOS, Android, Python, and WASM — no server, no cloud, no data risk." />
+    <meta name="description" content="Private, bi-temporal AI memory with hybrid search and eleven MCP tools. Runs on-device across Rust, iOS, Android, Python, and WASM — no server, no cloud." />
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#171311" />
     <link rel="canonical" href="https://kronroe.dev/" />
@@ -2350,6 +2381,115 @@
       .footer-notify-note a:hover {
         color: #fff;
       }
+      .hp-field {
+        position: absolute !important;
+        left: -9999px !important;
+        width: 1px !important;
+        height: 1px !important;
+        opacity: 0 !important;
+        pointer-events: none !important;
+      }
+      .privacy-console {
+        position: fixed;
+        right: 1rem;
+        bottom: 1rem;
+        z-index: 40;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.75rem;
+      }
+      .privacy-console-panel {
+        width: min(380px, calc(100vw - 2rem));
+        padding: 1rem 1rem 0.95rem;
+        border-radius: 22px;
+        border: 1px solid rgba(255,255,255,0.10);
+        background:
+          radial-gradient(circle at top right, rgba(124,92,252,0.18), transparent 32%),
+          radial-gradient(circle at bottom left, rgba(232,125,74,0.16), transparent 30%),
+          linear-gradient(180deg, rgba(26,21,16,0.96), rgba(20,16,14,0.98));
+        box-shadow: 0 24px 70px rgba(10, 8, 8, 0.34);
+        color: rgba(255,255,255,0.94);
+      }
+      .privacy-console-kicker {
+        font-family: var(--mono);
+        font-size: 0.66rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255,255,255,0.54);
+      }
+      .privacy-console-title {
+        margin-top: 0.5rem;
+        font-size: 1.15rem;
+        line-height: 1.15;
+        letter-spacing: -0.02em;
+      }
+      .privacy-console-copy {
+        margin-top: 0.5rem;
+        font-size: 0.9rem;
+        line-height: 1.6;
+        color: rgba(255,255,255,0.74);
+      }
+      .privacy-console-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+        margin-top: 0.9rem;
+      }
+      .privacy-console-btn,
+      .privacy-console-link,
+      .privacy-console-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        font-family: var(--body);
+        font-size: 0.82rem;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .privacy-console-btn {
+        border: 1px solid rgba(255,255,255,0.12);
+        padding: 0.56rem 0.92rem;
+        cursor: pointer;
+        background: transparent;
+        color: rgba(255,255,255,0.90);
+      }
+      .privacy-console-btn--primary {
+        background: linear-gradient(135deg, var(--violet), color-mix(in srgb, var(--violet) 68%, var(--copper)));
+        color: #fff;
+        box-shadow: 0 14px 28px rgba(124,92,252,0.24);
+      }
+      .privacy-console-btn--secondary:hover,
+      .privacy-console-btn--secondary:focus-visible {
+        border-color: rgba(255,255,255,0.26);
+        color: #fff;
+      }
+      .privacy-console-link {
+        padding: 0.56rem 0.2rem;
+        color: rgba(255,255,255,0.72);
+        text-underline-offset: 0.16em;
+      }
+      .privacy-console-link:hover,
+      .privacy-console-link:focus-visible {
+        color: #fff;
+      }
+      .privacy-console-pill {
+        gap: 0.42rem;
+        border: 1px solid rgba(255,255,255,0.10);
+        padding: 0.52rem 0.85rem;
+        background: rgba(23,19,17,0.92);
+        color: rgba(255,255,255,0.92);
+        box-shadow: 0 16px 36px rgba(20,16,14,0.24);
+        cursor: pointer;
+      }
+      .privacy-console-pill-state {
+        font-family: var(--mono);
+        font-size: 0.67rem;
+        color: rgba(255,255,255,0.56);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
 
       @media (max-width: 840px) {
         .analogy-strip { padding: 0 1.25rem; }
@@ -2425,6 +2565,18 @@
         .hero-cta { flex-direction: column; gap: 0.5rem; }
         .hero-cta .hero-btn { text-align: center; justify-content: center; }
         .footer-cta-chips { flex-direction: column; align-items: center; }
+        .privacy-console {
+          left: 1rem;
+          right: 1rem;
+          align-items: stretch;
+        }
+        .privacy-console-panel,
+        .privacy-console-pill {
+          width: 100%;
+        }
+        .privacy-console-pill {
+          justify-content: space-between;
+        }
       }
       @media (max-width: 480px) {
         .hero-install { flex-direction: column; align-items: stretch; }
@@ -2593,7 +2745,7 @@
         <!-- 5. CTA button -->
         <div class="hero-cta">
           <a href="#playground" class="hero-btn hero-btn-primary">Try the playground ↓</a>
-          <a href="mailto:hi@kronroe.dev?subject=Kronroe%20commercial%20licensing" class="hero-btn hero-btn-ghost">Commercial licensing</a>
+          <a href="/commercial/" class="hero-btn hero-btn-ghost">Commercial licensing</a>
         </div>
 
         <!-- 6. Fact timeline card + time scrubber (unified) -->
@@ -3211,7 +3363,7 @@
       <div class="footer-cta-inner">
         <span class="footer-cta-eyebrow">Deploy privately</span>
         <h2 class="footer-cta-headline reveal-on-scroll" id="heading-footer-cta">
-          Private memory.<br>Built to stay local.
+          Private memory.<span class="sr-only"> </span><br>Built to stay local.
         </h2>
         <p class="footer-cta-sub reveal-on-scroll">
           On-device memory with full history and point-in-time queries. Ships on iOS,
@@ -3232,9 +3384,9 @@
             <input type="email" name="email" placeholder="you@example.com" required autocomplete="email" aria-label="Email address for release notifications" class="footer-notify-input" />
             <button type="submit" class="footer-notify-btn" id="notify-btn">Notify me</button>
             <input type="hidden" name="_subject" value="Kronroe release notifications signup" />
-            <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off" />
+            <input type="text" name="_gotcha" class="hp-field" tabindex="-1" autocomplete="off" aria-hidden="true" />
           </form>
-          <p class="footer-notify-note" id="notify-note">No spam. Release announcements only. Privacy and licensing details are covered in the <a href="/faq/">FAQ</a> and the <a href="/commercial/">commercial licensing</a> page.</p>
+          <p class="footer-notify-note" id="notify-note">No spam. Release announcements only. Privacy details live in the <a href="/privacy/">privacy policy</a>, and licensing details live in the <a href="/commercial/">commercial licensing</a> page.</p>
         </div>
       </div>
     </section>
@@ -3253,6 +3405,7 @@
           <a href="/community/">Community</a>
           <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="https://pypi.org/project/kronroe/" target="_blank" rel="noopener noreferrer">PyPI</a>
@@ -3262,7 +3415,69 @@
       </div>
     </footer>
 
-  <div id="ts-tooltip"></div>
+    <div class="privacy-console" id="privacy-console">
+      <div class="privacy-console-panel" id="privacy-console-panel" role="dialog" aria-modal="false" aria-labelledby="privacy-console-title">
+        <div class="privacy-console-kicker">Privacy controls</div>
+        <h2 class="privacy-console-title" id="privacy-console-title">Site analytics are optional.</h2>
+        <p class="privacy-console-copy">
+          Kronroe the product stays local. This website can use lightweight analytics to understand visits only if you opt in.
+        </p>
+        <div class="privacy-console-actions">
+          <button type="button" class="privacy-console-btn privacy-console-btn--primary" data-privacy-action="accept">Allow analytics</button>
+          <button type="button" class="privacy-console-btn privacy-console-btn--secondary" data-privacy-action="decline">Keep analytics off</button>
+          <a class="privacy-console-link" href="/privacy/">Read privacy policy</a>
+        </div>
+      </div>
+      <button type="button" class="privacy-console-pill" id="privacy-console-pill" hidden>
+        <span>Privacy controls</span>
+        <span class="privacy-console-pill-state" id="privacy-console-state">analytics off</span>
+      </button>
+    </div>
+
+    <div id="ts-tooltip"></div>
+    <script>
+      (function () {
+        var root = document.getElementById('privacy-console');
+        var panel = document.getElementById('privacy-console-panel');
+        var pill = document.getElementById('privacy-console-pill');
+        var stateEl = document.getElementById('privacy-console-state');
+        if (!root || !panel || !pill || !window.kronroeAnalytics) return;
+
+        function labelFor(state) {
+          if (state === 'accepted') return 'analytics on';
+          if (state === 'declined') return 'analytics off';
+          return 'choose';
+        }
+
+        function sync() {
+          var state = window.kronroeAnalytics.getState();
+          var hasChoice = state === 'accepted' || state === 'declined';
+          panel.hidden = hasChoice;
+          pill.hidden = !hasChoice;
+          if (stateEl) stateEl.textContent = labelFor(state);
+        }
+
+        root.addEventListener('click', function (event) {
+          var target = event.target;
+          if (!(target instanceof HTMLElement)) return;
+          var action = target.getAttribute('data-privacy-action');
+          if (action === 'accept') {
+            window.kronroeAnalytics.accept();
+            sync();
+          } else if (action === 'decline') {
+            window.kronroeAnalytics.decline();
+            sync();
+          }
+        });
+
+        pill.addEventListener('click', function () {
+          panel.hidden = false;
+          pill.hidden = true;
+        });
+
+        sync();
+      })();
+    </script>
 
   </body>
 </html>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Learn why Kronroe exists, what it stands for, and how it approaches private on-device memory." />
-    <link rel="canonical" href="https://kronroe.dev/about/" />
+    <meta name="description" content="Privacy policy for Kronroe.dev and the optional site analytics, release notifications, and contact flows around the Kronroe product." />
+    <link rel="canonical" href="https://kronroe.dev/privacy/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon/favicon.ico" />
     <link rel="stylesheet" href="/page-shell.css" />
-    <title>About Kronroe</title>
+    <title>Privacy Policy — Kronroe</title>
   </head>
   <body>
     <header class="site-header">
@@ -27,7 +27,7 @@
           <text x="282" y="75" font-family="'Quicksand',system-ui,sans-serif" font-size="52" font-weight="700" letter-spacing="-1" fill="#E87D4A">roe</text>
         </svg>
       </a>
-      <span class="site-badge">About</span>
+      <span class="site-badge">Privacy</span>
       <nav class="site-nav" aria-label="Site">
         <a href="/docs/">Docs</a>
         <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
@@ -39,90 +39,82 @@
     </header>
     <main class="page">
       <section class="hero">
-        <span class="eyebrow">About Kronroe</span>
-        <h1>Private memory for products that should not need a cloud to stay smart.</h1>
+        <span class="eyebrow">Privacy policy</span>
+        <h1>Privacy should match the product story.</h1>
         <p class="lede">
-          Kronroe exists to give AI-native and privacy-sensitive products a real memory engine:
-          bi-temporal, on-device, and built to keep history intact without handing your data to a server.
+          Kronroe the product is designed to keep memory local. Kronroe.dev is simpler: the website can use optional analytics if you allow them, and release emails are opt-in. We do not sell personal data.
         </p>
         <div class="cta-row">
-          <a class="button button--primary" href="/#playground">Try the playground</a>
-          <a class="button button--ghost" href="/docs/">Read the docs</a>
+          <a class="button button--primary" href="/#playground">Open the homepage controls</a>
+          <a class="button button--ghost" href="/commercial/">Commercial licensing</a>
         </div>
       </section>
+
       <section class="texture-strip">
         <div class="texture-grid">
           <article class="texture-card">
-            <h3>Product thesis</h3>
-            <p>Kronroe is built for software that needs memory to be private, portable, and explainable.</p>
+            <h3>What stays local</h3>
+            <p>Kronroe’s in-browser playground runs the graph engine in WebAssembly. Facts you enter there stay in the browser session unless you explicitly export them.</p>
           </article>
           <article class="texture-card">
-            <h3>Why it feels different</h3>
-            <p>The site, docs, and playground all follow the same palette and tone so the product story stays coherent.</p>
+            <h3>What the site may collect</h3>
+            <p>If you allow analytics on the homepage, Kronroe.dev can record page views and basic device/browser information through Google Analytics.</p>
           </article>
           <article class="texture-card">
-            <h3>What you should expect</h3>
-            <p>A smaller, clearer API surface and a memory model that keeps history instead of overwriting it.</p>
+            <h3>What release emails use</h3>
+            <p>If you submit the release form, we store the email address you provide so we can send release announcements. Nothing else in that form is required.</p>
           </article>
         </div>
       </section>
+
       <section class="panel-grid stack">
         <article class="panel panel--violet">
-          <h2>Mission</h2>
-          <p>Make temporal memory practical for real apps: private, portable, and easy to reason about.</p>
+          <h2>Optional analytics</h2>
+          <p>Kronroe.dev keeps analytics off until you opt in through the homepage privacy controls. If you allow them, Google Analytics may process page URLs, referrers, approximate device/browser information, and similar traffic metrics so we can understand how the site is used.</p>
         </article>
         <article class="panel panel--copper">
-          <h2>Principles</h2>
-          <ul>
-            <li>Data should stay local unless you explicitly move it.</li>
-            <li>History should be queryable, not overwritten.</li>
-            <li>Technical clarity should feel calm and trustworthy.</li>
-          </ul>
+          <h2>Cookies and browser storage</h2>
+          <p>If analytics are enabled, Google Analytics may use cookies or similar browser identifiers. Separately, the homepage stores your analytics preference locally in your browser so the site remembers your choice.</p>
         </article>
         <article class="panel panel--lime">
-          <h2>Why now</h2>
-          <p>
-            AI assistants, mobile apps, and embedded systems are all asking for memory, but most memory
-            products were built for server-first workflows. Kronroe is the local-first answer.
-          </p>
+          <h2>Release notifications</h2>
+          <p>The release signup form is used only for release announcements. It is not a general marketing newsletter. We do not sell or trade that email list.</p>
         </article>
         <article class="panel">
-          <h2>What Kronroe is for</h2>
+          <h2>Commercial enquiries</h2>
+          <p>If you contact Kronroe about commercial licensing, we use the details you send to reply and handle that enquiry. Those messages are not shared for advertising.</p>
+        </article>
+        <article class="panel">
+          <h2>Your controls</h2>
           <ul>
-            <li>Products that need memory without turning every interaction into a server roundtrip.</li>
-            <li>Teams that want a clear temporal model for corrections, history, and auditability.</li>
-            <li>Builders who prefer a small, legible API surface over a large hidden service layer.</li>
+            <li>You can allow or decline site analytics from the homepage privacy controls.</li>
+            <li>You can ignore the release form and browse the site without signing up.</li>
+            <li>You can contact <a href="mailto:hi@kronroe.dev">hi@kronroe.dev</a> if you want your release-notification email removed.</li>
           </ul>
         </article>
         <article class="panel">
-          <h2>What Kronroe is not</h2>
+          <h2>What we do not do</h2>
           <ul>
-            <li>Not a cloud dependency disguised as local-first.</li>
-            <li>Not a generic vector store with a memory label on top.</li>
-            <li>Not a product that forces you to trade clarity for capability.</li>
+            <li>We do not sell personal data.</li>
+            <li>We do not turn the homepage playground into a cloud service.</li>
+            <li>We do not require an account just to evaluate Kronroe.</li>
           </ul>
-        </article>
-        <article class="panel">
-          <h2>How the story will expand</h2>
-          <p>
-            This page will hold the founder story, product philosophy, and the design choices behind the
-            brand once the rest of the site settles into its final shape.
-          </p>
         </article>
       </section>
+
       <section class="texture-strip texture-strip--dark">
-        <h2>What stays constant</h2>
-        <p>Kronroe keeps the same core idea everywhere: local-first memory, clear temporal behavior, and an interface that stays legible as the product grows.</p>
+        <h2>Questions?</h2>
+        <p>If something in this policy feels unclear, email <a href="mailto:hi@kronroe.dev">hi@kronroe.dev</a>. We would rather explain the tradeoffs plainly than hide them behind legal fog.</p>
       </section>
     </main>
     <footer class="footer">
       <div class="footer-inner">
-        <span>Kronroe · About</span>
+        <span>Kronroe · Privacy</span>
         <div class="footer-links">
           <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
           <a href="/community/">Community</a>
+          <a href="/about/">About</a>
           <a href="/faq/">FAQ</a>
-          <a href="/privacy/">Privacy</a>
           <a href="/docs/">Docs</a>
           <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -30,4 +30,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://kronroe.dev/privacy/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/site/scripts/build-docs.mjs
+++ b/site/scripts/build-docs.mjs
@@ -318,6 +318,19 @@ function wrapHtml({ title, intro, body, currentHref, sectionLabel, toc, nextUp }
       </article>
       ${toc}
     </main>
+    <footer class="footer">
+      <div class="footer-inner">
+        <span>Kronroe · Docs</span>
+        <div class="footer-links">
+          <a href="https://github.com/kronroe/kronroe/releases" target="_blank" rel="noopener noreferrer">Releases</a>
+          <a href="/community/">Community</a>
+          <a href="/about/">About</a>
+          <a href="/faq/">FAQ</a>
+          <a href="/privacy/">Privacy</a>
+          <a href="https://github.com/kronroe/kronroe" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
+      </div>
+    </footer>
     ${searchDialog()}
     <script type="module" src="/docs-search.js"></script>
     <script type="module" src="/docs-tabs.js"></script>


### PR DESCRIPTION
## Summary
- add a real `/privacy/` page for Kronroe.dev
- make site analytics opt-in with a branded privacy controls tray instead of loading Google Analytics by default
- route the homepage commercial CTA to `/commercial/` instead of a raw mailto
- improve trust copy around the release signup and add privacy links across site footers
- hide the signup honeypot from assistive tech and keep generated docs footers in sync

## Why
The site is now strong enough that trust and conversion details matter. This change makes the privacy story match the product story more closely, gives visitors a real privacy policy to read, and makes the commercial path feel more deliberate.

## Verification
- `npm run build` in `site/`
- verified the new privacy route is included in the site build
- confirmed docs generation still succeeds after the shared footer/template update