### PR TITLE
Add retry loop to post-deploy smoke test for CDN propagation

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -74,17 +74,32 @@ jobs:
           set -euo pipefail
           URL="${PLAYGROUND_URL:-https://kronroe.web.app}"
           echo "Smoke testing ${URL}"
-          HTTP_CODE=$(curl -o /dev/null -sL --compressed -w "%{http_code}" "${URL}")
-          if [ "${HTTP_CODE}" != "200" ]; then
-            echo "ERROR: ${URL} returned HTTP ${HTTP_CODE}" >&2
-            exit 1
-          fi
-          curl -sL --compressed "${URL}" | grep -q "Kronroe" || { echo "ERROR: page missing Kronroe content" >&2; exit 1; }
-          echo "Smoke test passed — HTTP ${HTTP_CODE}"
-          {
-            echo "## Post-Deploy Smoke Test"
-            echo ""
-            echo "- URL: ${URL}"
-            echo "- Status: HTTP ${HTTP_CODE}"
-            echo "- Content check: passed"
-          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Retry loop — Firebase CDN edge nodes may take a few seconds to propagate
+          MAX_RETRIES=4
+          for i in $(seq 1 $MAX_RETRIES); do
+            HTTP_CODE=$(curl -o /dev/null -sL --compressed -w "%{http_code}" "${URL}")
+            if [ "${HTTP_CODE}" != "200" ]; then
+              echo "Attempt ${i}/${MAX_RETRIES}: HTTP ${HTTP_CODE} — retrying in 5s..."
+              sleep 5
+              continue
+            fi
+            if curl -sL --compressed "${URL}" | grep -q "Kronroe"; then
+              echo "Smoke test passed on attempt ${i} — HTTP ${HTTP_CODE}"
+              {
+                echo "## Post-Deploy Smoke Test"
+                echo ""
+                echo "- URL: ${URL}"
+                echo "- Status: HTTP ${HTTP_CODE}"
+                echo "- Content check: passed (attempt ${i})"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "Attempt ${i}/${MAX_RETRIES}: HTTP 200 but content not yet propagated — retrying in 5s..."
+            sleep 5
+          done
+
+          echo "ERROR: smoke test failed after ${MAX_RETRIES} attempts" >&2
+          echo "Last HTTP code: ${HTTP_CODE}" >&2
+          curl -sL --compressed "${URL}" | head -c 500 >&2
+          exit 1


### PR DESCRIPTION
## Summary
- Post-deploy smoke test was failing intermittently (#174 deploy failed with "page missing Kronroe content")
- Root cause: Firebase CDN edge nodes take a few seconds to propagate after deploy — the `curl` hit a stale edge that hadn't received the new content yet
- Fix: retry loop with 4 attempts × 5s backoff (max 20s total wait)
- On final failure, dumps first 500 bytes of the response for easier debugging

## Test plan
- [ ] Merge and verify the deploy workflow succeeds on next site change
- [ ] The retry loop should pass on attempt 1 in most cases; CDN delay will be caught by retries 2-4
