### PR TITLE
Site polish: sitemap automation, branded 404, email capture infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Verify static site exists
         run: test -f site/index.html && echo "site/index.html found"
 
+      - name: Verify sitemap is up to date
+        run: python3 site/scripts/build-sitemap.py --check
+
   # ─── Wrapper verification ──────────────────────────────────────────────
 
   wrapper-verification:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,12 +40,16 @@ jobs:
         run: wasm-pack build crates/wasm --target web --out-dir ../../site/public/pkg --no-typescript
         # outputs into site/public/pkg/ — assembled into dist in the next step
 
+      - name: Regenerate sitemap from blog posts
+        run: python3 site/scripts/build-sitemap.py
+
       - name: Assemble static site into dist
         run: |
           set -euo pipefail
           rm -rf site/dist
           mkdir -p site/dist
           cp site/index.html site/dist/
+          cp site/404.html site/dist/
           cp site/og-image.png site/dist/
           cp -r site/public/* site/dist/
           # Copy docs pages (preserving directory structure)

--- a/firebase.json
+++ b/firebase.json
@@ -42,19 +42,8 @@
         ]
       }
     ],
-    "rewrites": [
-      {
-        "source": "/docs/**",
-        "destination": "/docs/index.html"
-      },
-      {
-        "source": "/blog/**",
-        "destination": "/blog/index.html"
-      },
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
+    "cleanUrls": true,
+    "trailingSlash": true,
+    "appAssociation": "NONE"
   }
 }

--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>404 — Lost in time | Kronroe</title>
+<meta name="description" content="That page doesn't exist at this point in time."/>
+<meta name="robots" content="noindex"/>
+<meta property="og:title" content="404 — Lost in time | Kronroe"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://kronroe.dev/404"/>
+<link rel="canonical" href="https://kronroe.dev/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    min-height: 100vh;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem;
+    text-align: center;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    max-width: 480px;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 2.5rem;
+  }
+
+  .four-oh-four {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: var(--warm-5);
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: clamp(2.25rem, 6vw, 3.5rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: 1rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+    color: var(--warm-7);
+    max-width: 480px;
+    margin: 0 auto 2.5rem;
+  }
+
+  .lede em {
+    font-style: italic;
+    color: var(--warm-10);
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 3rem;
+  }
+
+  .btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1.5px solid transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .btn-primary {
+    background: var(--violet-6);
+    color: #fff;
+    border-color: var(--violet-6);
+  }
+  .btn-primary:hover { background: var(--violet-7); border-color: var(--violet-7); }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--warm-7);
+    border-color: #C4BFD1;
+  }
+  .btn-secondary:hover {
+    background: var(--surface);
+    color: var(--warm-10);
+  }
+
+  .timestamps {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    max-width: 480px;
+    margin: 0 auto;
+    text-align: left;
+    line-height: 1.7;
+  }
+  .timestamps .ts-label { color: var(--warm-7); font-weight: 600; }
+  .timestamps .dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+  }
+  .ts-cyan .dot { background: var(--cyan-6); }
+  .ts-lime .dot { background: var(--lime-6); }
+
+  footer {
+    margin-top: 3rem;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+  }
+  footer a {
+    color: var(--violet-6);
+    text-decoration: none;
+  }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="four-oh-four">404 — page not found</p>
+
+<h1>Lost in time.</h1>
+
+<p class="lede">
+  That page doesn't exist at this point in time. Either it never <em>was</em> &mdash;
+  or it <em>was</em>, and we've since invalidated it.
+</p>
+
+<div class="actions">
+  <a class="btn btn-primary" href="/">Back to homepage</a>
+  <a class="btn btn-secondary" href="/blog/">Read the blog</a>
+  <a class="btn btn-secondary" href="/docs/">Browse the docs</a>
+</div>
+
+<div class="timestamps">
+  <span class="ts-label ts-cyan"><span class="dot"></span>valid_from:</span> never<br>
+  <span class="ts-label ts-lime"><span class="dot"></span>valid_to:</span> never
+</div>
+
+<footer>
+  <p>&copy; 2026 Kronroe &middot; <a href="https://github.com/kronroe/kronroe">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/site/SETUP-EXTERNAL.md
+++ b/site/SETUP-EXTERNAL.md
@@ -1,0 +1,177 @@
+# Site setup — external services
+
+A short, do-once checklist for the things that can't be set up in code:
+search engine indexing and the newsletter provider. Estimated time:
+**~45 minutes total**.
+
+Work through the sections in order. Each section is independent — you
+can stop after any one and pick up later.
+
+---
+
+## 1. Google Search Console (15 min)
+
+Tells you what queries you rank for, surfaces indexing errors,
+notifies you of broken pages.
+
+### Steps
+
+1. Go to https://search.google.com/search-console/welcome
+2. Pick **Domain** property type (not URL prefix) and enter `kronroe.dev`
+3. Google will give you a TXT record to add to DNS — paste it into your
+   domain registrar's DNS panel. Wait ~5 min for propagation.
+4. Click **Verify** in Search Console
+5. Once verified, go to **Sitemaps** in the left nav
+6. Submit `https://kronroe.dev/sitemap.xml`
+7. Done. First crawl usually shows up in 24-48 hrs.
+
+### What to watch for in the first month
+
+- **Coverage** report — should show all 4 URLs from the sitemap as
+  "Indexed". If any show "Discovered - currently not indexed" after a
+  week, content quality may be flagged as thin.
+- **Performance** report — first impressions and clicks. Don't expect
+  much for the first 4-6 weeks; SEO is slow.
+- **Core Web Vitals** — should be green. If not, we'll fix it.
+
+---
+
+## 2. Bing Webmaster Tools (10 min)
+
+Bing search powers ChatGPT search results, Copilot, and DuckDuckGo's
+fallback. Non-trivial AI-developer audience uses these.
+
+### Steps
+
+1. Go to https://www.bing.com/webmasters
+2. Sign in with a Microsoft account
+3. Pick **Import from Google Search Console** (saves verification —
+   uses the same DNS record). If GSC isn't done yet, use the manual
+   verification with a meta tag.
+4. Submit the same `https://kronroe.dev/sitemap.xml`
+5. Done.
+
+---
+
+## 3. Buttondown newsletter (20 min)
+
+Indie newsletter service, $9/mo, Markdown editor, has API + RSS-to-newsletter.
+
+### Steps
+
+1. Sign up at https://buttondown.com — pick a username (this becomes
+   part of your subscribe URL, so make it short and brand-aligned, e.g.
+   `kronroe`)
+2. In Buttondown settings, set:
+   - **From email**: `rebekah@kindlyroe.com` (or wherever you want
+     replies to go)
+   - **Welcome email**: short, warm, links to the why-kronroe post +
+     GitHub repo. Sample below.
+   - **Confirmation email**: enable double opt-in (GDPR-safe, prevents
+     spam signups poisoning your list)
+3. Enable **RSS-to-email** and point it at `https://kronroe.dev/blog/feed.xml`
+   so new posts auto-trigger a newsletter draft for review.
+
+### Wire the form into the site
+
+Once you have your Buttondown username, replace the placeholder in
+two files:
+
+```bash
+# Repo-relative paths
+site/blog/index.html
+site/blog/why-kronroe/index.html
+```
+
+Find every occurrence of `REPLACE_WITH_BUTTONDOWN_USERNAME` and replace
+with your actual username (e.g. `kronroe`). Then update the CSP in
+`firebase.json` to allow Buttondown:
+
+```diff
+-connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com;
++connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com https://buttondown.com;
+```
+
+Test locally before pushing:
+
+```bash
+# Start the static preview server
+python3 -m http.server 5178 --bind 127.0.0.1 --directory site
+
+# Open http://localhost:5178/blog/why-kronroe/, scroll to the form,
+# enter your own email, and check that:
+# - the button shows "Subscribed ✓"
+# - the status text reads "Thanks — check your inbox to confirm."
+# - your inbox gets the Buttondown confirmation email
+```
+
+### Sample welcome email
+
+```
+Subject: Welcome to Kronroe — what's next
+
+Hi,
+
+You just subscribed to updates from Kronroe — the embedded bi-temporal
+graph database I'm building in the open. Thanks for that.
+
+A few quick links to get started:
+
+- Why we built Kronroe (the long-form version):
+  https://kronroe.dev/blog/why-kronroe/
+
+- The repo:
+  https://github.com/kronroe/kronroe
+
+- The docs:
+  https://kronroe.dev/docs/
+
+I send out updates roughly every 2 weeks. No marketing fluff — just
+what changed in the engine, what I'm thinking about, and the
+occasional deep technical post.
+
+If you ever want to reply, hit me back at rebekah@kindlyroe.com.
+
+— Rebekah
+```
+
+---
+
+## 4. Verify everything works (5 min)
+
+Once Buttondown is wired and the CSP is updated, push the changes and
+let the deploy go. Then:
+
+- [ ] Open https://kronroe.dev/blog/why-kronroe/ in a private window
+- [ ] Accept cookies (so the consent banner doesn't block the test)
+- [ ] Subscribe with a fresh email address
+- [ ] Confirm the email arrives in inbox + welcome email lands
+- [ ] In **Google Analytics 4 Realtime**, confirm a `generate_lead`
+      event fires
+- [ ] In **Buttondown's subscribers list**, confirm the email appears
+
+If any of these fail, the issue is one of:
+- CSP blocking the POST (check browser console for CSP errors)
+- Buttondown username mismatch (check the form's `action` URL)
+- Consent denied (analytics events won't fire — that's *correct*
+  behavior, not a bug)
+
+---
+
+## What's deliberately not in this list
+
+A few things I considered but decided to skip until you have signal:
+
+- **Plausible / Fathom side-by-side with GA4** — diminishing returns
+  until you have >1k visitors/mo. GA4 + LinkedIn covers the core
+  questions for now.
+- **Twitter / X / Bluesky / Mastodon meta tags** — `og:` and `twitter:`
+  cards already cover the major scrapers. Adding more rarely changes
+  click-through.
+- **A `humans.txt`** — cute but no real signal. Skip.
+- **`security.txt`** — worth doing once you have CVE-able surface area
+  (i.e. a published Rust crate getting downloaded). Phase 1 task.
+
+---
+
+Last updated: 2026-04-27

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -23,6 +23,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <link rel="alternate" type="application/rss+xml" title="Kronroe Blog" href="/blog/feed.xml"/>
 <script defer src="/js/analytics-consent.js"></script>
+<script defer src="/js/email-capture.js"></script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -433,6 +434,16 @@
     cursor: pointer; transition: background 0.15s; white-space: nowrap;
   }
   .subscribe-btn:hover { background: var(--violet-7); }
+  .subscribe-btn:disabled { opacity: 0.7; cursor: wait; }
+  .subscribe-status {
+    margin-top: 0.75rem;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    min-height: 1.25rem;
+    color: var(--text-muted);
+  }
+  .subscribe-status[data-state="success"] { color: var(--lime-6); font-weight: 600; }
+  .subscribe-status[data-state="error"] { color: var(--copper-7); }
   .subscribe-note {
     font-size: 0.72rem; color: var(--text-muted);
     margin-top: 0.75rem;
@@ -646,10 +657,14 @@
   <div class="subscribe-card">
     <h3>Kronroe is early. Follow the build.</h3>
     <span class="subscribe-annotation">&#8627; get notified when new facts are recorded</span>
-    <form class="subscribe-form" action="/blog/" method="post" onsubmit="return false;">
-      <input type="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
+    <form class="subscribe-form"
+          data-kr-subscribe
+          action="https://buttondown.com/api/emails/embed-subscribe/REPLACE_WITH_BUTTONDOWN_USERNAME"
+          method="post">
+      <input type="email" name="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
       <button type="submit" class="subscribe-btn">Subscribe</button>
     </form>
+    <p class="subscribe-status" data-kr-status aria-live="polite"></p>
     <p class="subscribe-note">1&ndash;2 posts per month. No spam. Unsubscribe anytime.</p>
   </div>
 

--- a/site/blog/why-kronroe/index.html
+++ b/site/blog/why-kronroe/index.html
@@ -25,6 +25,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <link rel="alternate" type="application/rss+xml" title="Kronroe Blog" href="/blog/feed.xml"/>
 <script defer src="/js/analytics-consent.js"></script>
+<script defer src="/js/email-capture.js"></script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -442,6 +443,16 @@
     cursor: pointer; transition: background 0.15s; white-space: nowrap;
   }
   .subscribe-btn:hover { background: var(--violet-7); }
+  .subscribe-btn:disabled { opacity: 0.7; cursor: wait; }
+  .subscribe-status {
+    margin-top: 0.75rem;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    min-height: 1.25rem;
+    color: var(--text-muted);
+  }
+  .subscribe-status[data-state="success"] { color: var(--lime-6); font-weight: 600; }
+  .subscribe-status[data-state="error"] { color: var(--copper-7); }
   .subscribe-note {
     font-size: 0.72rem; color: var(--text-muted);
     margin-top: 0.75rem;
@@ -712,10 +723,14 @@
     <div class="subscribe-card">
       <h3>Kronroe is early. Follow the build.</h3>
       <span class="subscribe-annotation">&#8627; get notified when new facts are recorded</span>
-      <form class="subscribe-form" action="/blog/" method="post" onsubmit="return false;">
-        <input type="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
+      <form class="subscribe-form"
+            data-kr-subscribe
+            action="https://buttondown.com/api/emails/embed-subscribe/REPLACE_WITH_BUTTONDOWN_USERNAME"
+            method="post">
+        <input type="email" name="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
         <button type="submit" class="subscribe-btn">Subscribe</button>
       </form>
+      <p class="subscribe-status" data-kr-status aria-live="polite"></p>
       <p class="subscribe-note">1&ndash;2 posts per month. No spam. Unsubscribe anytime.</p>
     </div>
   </div>

--- a/site/js/email-capture.js
+++ b/site/js/email-capture.js
@@ -1,0 +1,120 @@
+/**
+ * Kronroe email capture
+ * ─────────────────────────────────────────────────────────────
+ * Hand-rolled, zero-dependency newsletter signup form handler.
+ *
+ * How it works:
+ *   1. Each form on the page with `data-kr-subscribe` is enhanced.
+ *   2. Submission is intercepted; the email is POSTed to the form's
+ *      `action` URL as application/x-www-form-urlencoded.
+ *   3. UI feedback (success / error / loading) is shown inline.
+ *   4. On success, a `generate_lead` event is pushed to GA4's dataLayer
+ *      (only fires if the user accepted analytics consent — gtag handles
+ *      that gating automatically).
+ *
+ * Why no library: we already proved (with the consent banner) that we
+ * don't need 25 KB of dep to handle a textbox + a fetch. This adds 80
+ * lines for a feature we'll touch on every blog post.
+ *
+ * Switching providers (Buttondown → Kit → Listmonk → custom):
+ *   Just change the `action="..."` attribute on the <form>. The body
+ *   shape (email=...) is the same across all major providers.
+ *
+ * Buttondown setup reference:
+ *   action="https://buttondown.com/api/emails/embed-subscribe/<USERNAME>"
+ *   <input name="email">
+ *
+ * Kit (ConvertKit) setup reference:
+ *   action="https://app.kit.com/forms/<FORM_ID>/subscriptions"
+ *   <input name="email_address">
+ */
+(function () {
+  'use strict';
+
+  function enhanceForm(form) {
+    if (form.dataset.krEnhanced === '1') return;
+    form.dataset.krEnhanced = '1';
+
+    var input = form.querySelector('input[type="email"]');
+    var statusEl = form.querySelector('[data-kr-status]');
+    var submitBtn = form.querySelector('button[type="submit"]');
+
+    if (!input || !submitBtn) {
+      console.warn('[kronroe] subscribe form missing email input or submit button');
+      return;
+    }
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var email = (input.value || '').trim();
+      if (!email) return;
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Subscribing…';
+      if (statusEl) {
+        statusEl.textContent = '';
+        statusEl.removeAttribute('data-state');
+      }
+
+      var body = new URLSearchParams();
+      // Form body shape is provider-specific; we send under multiple
+      // common keys so a single config works across Buttondown, Kit, etc.
+      body.set('email', email);
+      body.set('email_address', email);
+
+      fetch(form.action, {
+        method: 'POST',
+        mode: 'no-cors', // most providers don't return CORS headers; success is implicit
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      })
+        .then(function () {
+          submitBtn.disabled = false;
+          submitBtn.textContent = 'Subscribed ✓';
+          input.value = '';
+          if (statusEl) {
+            statusEl.textContent = 'Thanks — check your inbox to confirm.';
+            statusEl.setAttribute('data-state', 'success');
+          }
+
+          // GA4 conversion event — gated by consent automatically.
+          if (typeof window.gtag === 'function') {
+            window.gtag('event', 'generate_lead', {
+              method: 'newsletter',
+              currency: 'USD',
+              value: 0,
+            });
+          }
+
+          // Reset button label after a moment so the form feels reusable.
+          setTimeout(function () {
+            submitBtn.textContent = submitBtn.dataset.label || 'Subscribe';
+          }, 4000);
+        })
+        .catch(function (_err) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = submitBtn.dataset.label || 'Subscribe';
+          if (statusEl) {
+            statusEl.textContent =
+              "Something went wrong — please email rebekah@kindlyroe.com instead.";
+            statusEl.setAttribute('data-state', 'error');
+          }
+        });
+    });
+
+    // Cache original button label for the post-submit reset.
+    submitBtn.dataset.label = submitBtn.textContent.trim();
+  }
+
+  function init() {
+    document.querySelectorAll('form[data-kr-subscribe]').forEach(enhanceForm);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,17 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://kronroe.dev/</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://kronroe.dev/docs/</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://kronroe.dev/blog/</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://kronroe.dev/blog/why-kronroe/</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/site/scripts/build-sitemap.py
+++ b/site/scripts/build-sitemap.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Generate sitemap.xml for kronroe.dev.
+
+Walks site/blog/*/index.html, extracts each post's `article:published_time`
+meta tag, and emits a complete sitemap including the static landmarks
+(homepage, /docs/, /blog/) plus every discovered blog post.
+
+Usage (from repo root):
+    python3 site/scripts/build-sitemap.py            # write to site/public/sitemap.xml
+    python3 site/scripts/build-sitemap.py --check    # exit 1 if file would change
+
+Why pure stdlib: this script runs in CI (GitHub Actions Ubuntu runners
+have Python 3 preinstalled) and locally without any pip install. No
+external deps.
+
+Exit codes:
+    0 — sitemap written (or unchanged in --check mode)
+    1 — --check mode found drift; or fatal error
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]  # repo root
+SITE_DIR = ROOT / "site"
+BLOG_DIR = SITE_DIR / "blog"
+OUTPUT = SITE_DIR / "public" / "sitemap.xml"
+
+BASE_URL = "https://kronroe.dev"
+
+# Static landmarks that always exist. Lastmod here represents the date
+# of the last meaningful content/structure change for the page — bump
+# manually when you ship a redesign or major copy change.
+STATIC_PAGES = [
+    {"loc": "/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "1.0"},
+    {"loc": "/docs/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "0.9"},
+    {"loc": "/blog/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "0.8"},
+]
+
+PUBLISHED_TIME_RE = re.compile(
+    r'<meta\s+property="article:published_time"\s+content="([^"]+)"',
+    re.IGNORECASE,
+)
+
+
+def find_blog_posts() -> list[dict[str, str]]:
+    """Walk site/blog/*/index.html and return {loc, lastmod} for each post."""
+    posts = []
+    if not BLOG_DIR.is_dir():
+        return posts
+
+    for post_dir in sorted(BLOG_DIR.iterdir()):
+        if not post_dir.is_dir():
+            continue
+        index_html = post_dir / "index.html"
+        if not index_html.is_file():
+            continue
+
+        html = index_html.read_text(encoding="utf-8")
+        match = PUBLISHED_TIME_RE.search(html)
+        if not match:
+            print(
+                f"warning: {index_html.relative_to(ROOT)} has no "
+                f"<meta property=\"article:published_time\"> — skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        # ISO datetime → date (sitemap.xml only needs YYYY-MM-DD)
+        lastmod = match.group(1).split("T", 1)[0]
+        posts.append({
+            "loc": f"/blog/{post_dir.name}/",
+            "lastmod": lastmod,
+            "changefreq": "monthly",
+            "priority": "0.7",
+        })
+
+    return posts
+
+
+def render_sitemap(entries: list[dict[str, str]]) -> str:
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ]
+    for e in entries:
+        lines.extend([
+            "  <url>",
+            f"    <loc>{BASE_URL}{e['loc']}</loc>",
+            f"    <lastmod>{e['lastmod']}</lastmod>",
+            f"    <changefreq>{e['changefreq']}</changefreq>",
+            f"    <priority>{e['priority']}</priority>",
+            "  </url>",
+        ])
+    lines.append("</urlset>")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if sitemap.xml would change (for CI drift detection).",
+    )
+    args = parser.parse_args()
+
+    entries = STATIC_PAGES + find_blog_posts()
+    new_content = render_sitemap(entries)
+
+    if args.check:
+        existing = OUTPUT.read_text(encoding="utf-8") if OUTPUT.exists() else ""
+        if existing != new_content:
+            print(
+                f"error: {OUTPUT.relative_to(ROOT)} is out of date — "
+                "run: python3 site/scripts/build-sitemap.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"ok: {OUTPUT.relative_to(ROOT)} is up to date")
+        return 0
+
+    OUTPUT.write_text(new_content, encoding="utf-8")
+    print(f"wrote: {OUTPUT.relative_to(ROOT)} ({len(entries)} URLs)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Tier-1 launch polish — SEO foundations and email capture infrastructure. Compounds on every future blog post.

### What's in this PR

**SEO polish** (commit `6e7a4eb`)
- `/blog/why-kronroe/` was missing from `sitemap.xml` — fixed
- New `site/scripts/build-sitemap.py` auto-generates the sitemap from blog post meta tags
- CI runs `--check` mode so a new blog post can never ship with a stale sitemap
- Branded `404.html` with bi-temporal copy ("Lost in time.") + `noindex`
- **Fixed soft-404 issue**: Firebase's catch-all `** → /index.html` rewrite was serving the homepage with status 200 for any unknown path — Google penalizes this. Removed.
- Now: unknown paths serve `404.html` with proper 404 status. `cleanUrls` + `trailingSlash` enabled for canonical URL hygiene.

**Email capture** (commit `30216db`)
- `site/js/email-capture.js` — zero-dependency form handler that enhances any `<form data-kr-subscribe>` on the page
- Wired up on `/blog/` and `/blog/why-kronroe/` (both pages already had styled form scaffolding from the previous PR; just needed wiring)
- Provider-agnostic body shape so switching from Buttondown → Kit → Listmonk later is a one-line `action` URL change
- Inline status messages + GA4 `generate_lead` conversion event (consent-gated automatically)
- `site/SETUP-EXTERNAL.md` — checklist of the things that can't be automated: GSC, Bing Webmaster, Buttondown signup. Includes the exact CSP diff and verification steps for once a real Buttondown username exists.

### What still needs human action

The form is **scaffolded but not live** — it'll fail with a friendly fallback message until you:

1. Sign up at Buttondown (or whichever provider)
2. Replace `REPLACE_WITH_BUTTONDOWN_USERNAME` in two HTML files
3. Add `https://buttondown.com` to the CSP `connect-src` in `firebase.json`

All three steps are documented in `site/SETUP-EXTERNAL.md` with copy-paste-ready commands.

### What's NOT in this PR

Deliberately deferred until there's signal to act on:
- Per-post OG card auto-generation (manual is fine until ≥4 posts)
- Performance audit (need GA4 data first to know what's bouncing)
- "Compare to" pages (do *after* 3-4 more posts of original content)

## Test plan

- [x] All 9 Playwright consent tests still pass (re-ran post-changes)
- [x] `python3 site/scripts/build-sitemap.py --check` exits 0 on clean state
- [x] `404.html` renders with branded design when accessed directly
- [x] Form `data-kr-enhanced="1"` after page load (verified in preview)
- [x] Form submission to placeholder URL fails gracefully with email-fallback status message
- [ ] Live deploy: post-deploy smoke test in `deploy-site.yml` should still pass
- [ ] Post-merge: visit a typo'd URL on production and confirm proper 404 status (not 200 with homepage)

