### PR TITLE
Wire Buttondown newsletter; document Keila migration plan

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -60,6 +60,10 @@ jobs:
           if [ -d site/blog ]; then
             cp -r site/blog site/dist/blog
           fi
+          # Copy newsletter landing pages (subscribe / confirmed)
+          if [ -d site/newsletter ]; then
+            cp -r site/newsletter site/dist/newsletter
+          fi
           echo "Assembled site/dist/:"
           ls -la site/dist/
 

--- a/firebase.json
+++ b/firebase.json
@@ -11,7 +11,7 @@
           { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" },
           { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
           { "key": "Cross-Origin-Opener-Policy","value": "same-origin" },
-          { "key": "Content-Security-Policy",   "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://snap.licdn.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: https://kronroe.dev https://www.google-analytics.com https://px.ads.linkedin.com https://www.linkedin.com; connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com; object-src 'none'; base-uri 'self';" }
+          { "key": "Content-Security-Policy",   "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://snap.licdn.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: https://kronroe.dev https://www.google-analytics.com https://px.ads.linkedin.com https://www.linkedin.com; connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com https://buttondown.com https://buttondown.email; object-src 'none'; base-uri 'self';" }
         ]
       },
       {

--- a/site/SETUP-EXTERNAL.md
+++ b/site/SETUP-EXTERNAL.md
@@ -1,176 +1,204 @@
 # Site setup — external services
 
-A short, do-once checklist for the things that can't be set up in code:
-search engine indexing and the newsletter provider. Estimated time:
-**~45 minutes total**.
-
-Work through the sections in order. Each section is independent — you
-can stop after any one and pick up later.
+A short reference for the external services that can't be set up in
+code: search engine indexing and the newsletter provider.
 
 ---
 
-## 1. Google Search Console (15 min)
+## Status (as of 2026-04-27)
+
+| Service | Status | Notes |
+|---|---|---|
+| **Google Search Console** | ✅ Verified, sitemap submitted | 4-URL sitemap will reflect on next deploy |
+| **Bing Webmaster Tools** | ✅ Verified via GSC import, sitemap submitted | IndexNow not yet wired (see deferred work below) |
+| **Buttondown** | ✅ Wired up — username `Kronroe` | Free tier, Keila is the long-term target (see migration plan) |
+
+---
+
+## 1. Google Search Console
 
 Tells you what queries you rank for, surfaces indexing errors,
 notifies you of broken pages.
 
-### Steps
+### Setup (already done)
 
-1. Go to https://search.google.com/search-console/welcome
-2. Pick **Domain** property type (not URL prefix) and enter `kronroe.dev`
-3. Google will give you a TXT record to add to DNS — paste it into your
-   domain registrar's DNS panel. Wait ~5 min for propagation.
-4. Click **Verify** in Search Console
-5. Once verified, go to **Sitemaps** in the left nav
-6. Submit `https://kronroe.dev/sitemap.xml`
-7. Done. First crawl usually shows up in 24-48 hrs.
+1. https://search.google.com/search-console/welcome
+2. Domain property type, entered `kronroe.dev`
+3. DNS TXT record added at registrar, verified
+4. Submitted `https://kronroe.dev/sitemap.xml`
 
-### What to watch for in the first month
+### What to watch for
 
-- **Coverage** report — should show all 4 URLs from the sitemap as
-  "Indexed". If any show "Discovered - currently not indexed" after a
-  week, content quality may be flagged as thin.
-- **Performance** report — first impressions and clicks. Don't expect
+- **Coverage report** (left nav → Pages) — should show all 4 URLs as
+  "Indexed" within ~7 days. If any show "Discovered - currently not
+  indexed" after a week, content quality may be flagged as thin.
+- **Performance report** — first impressions and clicks. Don't expect
   much for the first 4-6 weeks; SEO is slow.
-- **Core Web Vitals** — should be green. If not, we'll fix it.
+- **Core Web Vitals** — should be green. Re-check after a week of GA4
+  data accumulates.
+
+### When to re-submit the sitemap
+
+Re-submission isn't needed for routine content updates — Google
+recrawls automatically based on `lastmod` tags. Only re-submit if:
+
+- The sitemap URL itself changes (it won't — `sitemap.xml` is stable)
+- You've made a major site restructure with many URL changes
+- You see "Couldn't fetch" status and need to retry
 
 ---
 
-## 2. Bing Webmaster Tools (10 min)
+## 2. Bing Webmaster Tools
 
 Bing search powers ChatGPT search results, Copilot, and DuckDuckGo's
 fallback. Non-trivial AI-developer audience uses these.
 
-### Steps
+### Setup (already done)
 
-1. Go to https://www.bing.com/webmasters
-2. Sign in with a Microsoft account
-3. Pick **Import from Google Search Console** (saves verification —
-   uses the same DNS record). If GSC isn't done yet, use the manual
-   verification with a meta tag.
-4. Submit the same `https://kronroe.dev/sitemap.xml`
-5. Done.
+1. https://www.bing.com/webmasters
+2. Imported from Google Search Console (same DNS verification)
+3. Submitted same `https://kronroe.dev/sitemap.xml`
 
----
+### Deferred: IndexNow integration
 
-## 3. Buttondown newsletter (20 min)
+[IndexNow](https://www.indexnow.org/) lets you ping Bing/Yandex/DuckDuckGo
+the moment a new page goes live, instead of waiting for crawl. Useful
+once posting cadence is established (say, ≥4 posts).
 
-Indie newsletter service, $9/mo, Markdown editor, has API + RSS-to-newsletter.
+To enable later:
 
-### Steps
+1. In Bing Webmaster Tools, generate an IndexNow key
+2. Drop the key file at `site/public/<key>.txt` (Bing tells you the
+   exact filename)
+3. Add a step in `.github/workflows/deploy-site.yml` that POSTs the
+   list of changed URLs to `https://api.indexnow.org/indexnow` after
+   each deploy
 
-1. Sign up at https://buttondown.com — pick a username (this becomes
-   part of your subscribe URL, so make it short and brand-aligned, e.g.
-   `kronroe`)
-2. In Buttondown settings, set:
-   - **From email**: `rebekah@kindlyroe.com` (or wherever you want
-     replies to go)
-   - **Welcome email**: short, warm, links to the why-kronroe post +
-     GitHub repo. Sample below.
-   - **Confirmation email**: enable double opt-in (GDPR-safe, prevents
-     spam signups poisoning your list)
-3. Enable **RSS-to-email** and point it at `https://kronroe.dev/blog/feed.xml`
-   so new posts auto-trigger a newsletter draft for review.
-
-### Wire the form into the site
-
-Once you have your Buttondown username, replace the placeholder in
-two files:
-
-```bash
-# Repo-relative paths
-site/blog/index.html
-site/blog/why-kronroe/index.html
-```
-
-Find every occurrence of `REPLACE_WITH_BUTTONDOWN_USERNAME` and replace
-with your actual username (e.g. `kronroe`). Then update the CSP in
-`firebase.json` to allow Buttondown:
-
-```diff
--connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com;
-+connect-src 'self' ws: wss: https://www.google-analytics.com https://analytics.google.com https://px.ads.linkedin.com https://buttondown.com;
-```
-
-Test locally before pushing:
-
-```bash
-# Start the static preview server
-python3 -m http.server 5178 --bind 127.0.0.1 --directory site
-
-# Open http://localhost:5178/blog/why-kronroe/, scroll to the form,
-# enter your own email, and check that:
-# - the button shows "Subscribed ✓"
-# - the status text reads "Thanks — check your inbox to confirm."
-# - your inbox gets the Buttondown confirmation email
-```
-
-### Sample welcome email
-
-```
-Subject: Welcome to Kronroe — what's next
-
-Hi,
-
-You just subscribed to updates from Kronroe — the embedded bi-temporal
-graph database I'm building in the open. Thanks for that.
-
-A few quick links to get started:
-
-- Why we built Kronroe (the long-form version):
-  https://kronroe.dev/blog/why-kronroe/
-
-- The repo:
-  https://github.com/kronroe/kronroe
-
-- The docs:
-  https://kronroe.dev/docs/
-
-I send out updates roughly every 2 weeks. No marketing fluff — just
-what changed in the engine, what I'm thinking about, and the
-occasional deep technical post.
-
-If you ever want to reply, hit me back at rebekah@kindlyroe.com.
-
-— Rebekah
-```
+Skip until you're posting weekly+ — manual "Request indexing" via the
+URL Inspection tool is faster than building this for infrequent posts.
 
 ---
 
-## 4. Verify everything works (5 min)
+## 3. Newsletter — Buttondown (current) → Keila (target)
 
-Once Buttondown is wired and the CSP is updated, push the changes and
-let the deploy go. Then:
+### Why this two-stage decision
 
-- [ ] Open https://kronroe.dev/blog/why-kronroe/ in a private window
-- [ ] Accept cookies (so the consent banner doesn't block the test)
-- [ ] Subscribe with a fresh email address
-- [ ] Confirm the email arrives in inbox + welcome email lands
-- [ ] In **Google Analytics 4 Realtime**, confirm a `generate_lead`
-      event fires
-- [ ] In **Buttondown's subscribers list**, confirm the email appears
+We evaluated Buttondown, Keila (managed + self-hosted), Listmonk,
+Ghost (Pro + self-hosted), Beehiiv, Substack, and GCP-native options.
+The two real contenders were **Buttondown** and **Keila**.
 
-If any of these fail, the issue is one of:
-- CSP blocking the POST (check browser console for CSP errors)
-- Buttondown username mismatch (check the form's `action` URL)
-- Consent denied (analytics events won't fire — that's *correct*
-  behavior, not a bug)
+**Keila is our long-term target** — AGPL-3.0 (matches Kronroe), EU
+hosted, privacy-first, has a clean self-host migration path. But Keila
+has no free tier; managed costs ~€9/mo from day one.
+
+**Buttondown is our on-ramp** — free tier covers up to 100 subscribers
+(£0/mo), 5-minute setup, has native RSS-to-email automation. Lets us
+launch newsletter capture with zero ongoing cost until traction
+justifies the spend.
+
+### Buttondown configuration (already done)
+
+- **Username**: `Kronroe`
+- **Subscribe endpoint**: `https://buttondown.com/api/emails/embed-subscribe/Kronroe`
+- **From email**: `rebekah@kindlyroe.com`
+- **Double opt-in**: enabled
+- **RSS-to-email**: pointed at `https://kronroe.dev/blog/feed.xml`, **draft mode**
+- **Welcome email**: configured with brand voice + key links
+
+### What's wired into the site
+
+- `site/blog/index.html` and `site/blog/why-kronroe/index.html` have
+  `<form data-kr-subscribe action="...buttondown.com/...Kronroe">`
+- `site/js/email-capture.js` sends both `email` and `email_address`
+  body keys (provider-agnostic — works for Keila/Kit/Listmonk too)
+- CSP `connect-src` allows `https://buttondown.com` and
+  `https://buttondown.email`
+- GA4 `generate_lead` event fires on successful subscribe
+  (consent-gated automatically)
+
+### Migration triggers — when to switch to Keila
+
+Move to Keila managed when **any one** of these is true:
+
+| Signal | Threshold | Why this matters |
+|---|---|---|
+| Subscriber count | **≥80** | Approaching Buttondown's free-tier limit (100); migration before forced upgrade keeps optionality |
+| PyPI downloads | **≥500/mo** for `kronroe-mcp` or `kronroe-py` | Real adoption signal — we're past idle phase |
+| Commercial license interest | **First serious enquiry** | Brand alignment matters more once we're in commercial conversations; AGPL-on-AGPL is a clean story |
+| Posting cadence | **6+ posts published over 3 months** | Content marketing is sticking; investing in a better newsletter stack is justified |
+
+### Migration steps (for when the trigger fires)
+
+The migration is intentionally small because we built it that way.
+
+1. **Sign up at keila.io managed** (€9/mo) — pick `Kronroe` workspace
+2. **Export subscribers from Buttondown** as CSV — Settings →
+   Subscribers → Export
+3. **Import the CSV into Keila** — Subscribers → Import. Keila
+   preserves consent timestamps; double-check after import.
+4. **Get the Keila form endpoint** — Settings → Forms → Embed
+5. **Update two HTML files** — replace
+   `https://buttondown.com/api/emails/embed-subscribe/Kronroe` with
+   the new Keila form URL in:
+   - `site/blog/index.html`
+   - `site/blog/why-kronroe/index.html`
+6. **Update CSP in `firebase.json`** — replace
+   `https://buttondown.com https://buttondown.email` in `connect-src`
+   with `https://keila.io` (or the self-hosted domain if you've gone
+   that far)
+7. **Reconfigure RSS-to-email in Keila** — point at
+   `https://kronroe.dev/blog/feed.xml`, draft mode
+8. **Cancel Buttondown** — keep the account dormant for 30 days as a
+   read-only fallback in case the migration revealed any issues, then
+   delete
+
+Estimated migration time: **30-60 minutes**. Most of that is waiting
+for DNS/CSP to propagate.
+
+### Open improvement (deferred)
+
+The RSS feed at `/blog/feed.xml` currently has `<description>` summaries
+but no `<content:encoded>` with the full post body. This means
+RSS-to-email creates "click to read more" emails rather than embedding
+the full post.
+
+For "draft mode" workflow (where you review each newsletter), this is
+fine — you'd add the body manually before sending. If you ever want
+full-post auto-emails, extend `site/scripts/build-sitemap.py` into a
+sister script `build-feed.py` that walks each post's HTML body and
+embeds it as `<![CDATA[...]]>` in `<content:encoded>`. Estimated 30
+minutes of work.
 
 ---
 
-## What's deliberately not in this list
+## 4. Verification — confirm Buttondown wiring works end-to-end
 
-A few things I considered but decided to skip until you have signal:
+Once the next deploy lands (PR #178 merging), test the full subscribe
+flow:
 
-- **Plausible / Fathom side-by-side with GA4** — diminishing returns
-  until you have >1k visitors/mo. GA4 + LinkedIn covers the core
-  questions for now.
-- **Twitter / X / Bluesky / Mastodon meta tags** — `og:` and `twitter:`
-  cards already cover the major scrapers. Adding more rarely changes
-  click-through.
-- **A `humans.txt`** — cute but no real signal. Skip.
-- **`security.txt`** — worth doing once you have CVE-able surface area
-  (i.e. a published Rust crate getting downloaded). Phase 1 task.
+1. Open `https://kronroe.dev/blog/why-kronroe/` in a private window
+2. **Accept cookies** in the consent banner (otherwise GA events won't
+   fire — that's correct gating, not a bug)
+3. Scroll to the subscribe card at the bottom
+4. Enter a fresh email address you control
+5. Click **Subscribe**
+6. Check that:
+   - [ ] The button shows "Subscribed ✓"
+   - [ ] The status text reads "Thanks — check your inbox to confirm."
+   - [ ] Your inbox receives the Buttondown confirmation email
+   - [ ] After confirming, the welcome email arrives
+   - [ ] In **Buttondown subscribers list**, the email appears
+   - [ ] In **GA4 Realtime → Events**, a `generate_lead` event fires
+
+If any step fails, the issue is one of:
+
+- **CSP blocking the POST** — open browser console, look for CSP
+  violations. The fix is almost always a missing host in
+  `connect-src`.
+- **Username case mismatch** — Buttondown's URLs are case-sensitive.
+  We're using `Kronroe` (capital K). If the form 404s, double-check.
+- **Consent denied** — analytics events won't fire. This is *correct*
+  behavior, not a bug. Subscribe will still work; just no GA event.
 
 ---
 

--- a/site/SETUP-EXTERNAL.md
+++ b/site/SETUP-EXTERNAL.md
@@ -96,14 +96,65 @@ has no free tier; managed costs ~€9/mo from day one.
 launch newsletter capture with zero ongoing cost until traction
 justifies the spend.
 
-### Buttondown configuration (already done)
+### Buttondown configuration
+
+What's wired in code (already done):
 
 - **Username**: `Kronroe`
 - **Subscribe endpoint**: `https://buttondown.com/api/emails/embed-subscribe/Kronroe`
-- **From email**: `rebekah@kindlyroe.com`
-- **Double opt-in**: enabled
-- **RSS-to-email**: pointed at `https://kronroe.dev/blog/feed.xml`, **draft mode**
-- **Welcome email**: configured with brand voice + key links
+- **Form-submit redirect**: `/newsletter/thanks/` (handled in `email-capture.js`)
+
+What you need to configure in the Buttondown UI:
+
+- **Settings → General → Newsletter name**: `Kronroe Notes`
+- **Settings → General → Description**: see suggested copy below
+- **Settings → Email setup → From email**: `rebekah@kindlyroe.com`
+- **Settings → Email setup → From name**: `Rebekah Cole`
+- **Settings → Subscribers → Confirmation emails**: enable double opt-in
+- **Settings → Subscribing → After subscribing**: `https://kronroe.dev/newsletter/thanks/`
+   *(only used as a fallback for non-JS users — JS handler redirects there directly)*
+- **Settings → Subscribing → After confirming**: `https://kronroe.dev/newsletter/confirmed/`
+   *(this one is critical — Buttondown handles the email-link confirmation server-side and redirects here)*
+- **Automations → RSS feeds**: feed URL `https://kronroe.dev/blog/feed.xml`, mode **Draft**
+- **Automations → Welcome email**: enable + paste in welcome copy
+
+#### Suggested newsletter description
+
+> Build notes from Kronroe — the embedded bi-temporal graph database
+> for AI agent memory and mobile/edge apps. New posts roughly every
+> two weeks: technical decisions, what changed in the engine,
+> occasional deep dives. Built and written by Rebekah Cole.
+
+#### Suggested welcome email
+
+```
+Subject: Welcome to Kronroe Notes — what's next
+
+Hi,
+
+You just confirmed your subscription to Kronroe Notes — build updates
+from the embedded bi-temporal graph database I'm working on in the
+open. Thanks for that.
+
+A few quick links:
+
+→ Why we built Kronroe (long-form):
+  https://kronroe.dev/blog/why-kronroe/
+
+→ The repo:
+  https://github.com/kronroe/kronroe
+
+→ The docs:
+  https://kronroe.dev/docs/
+
+I'll send updates roughly every 2 weeks — what changed in the engine,
+what I'm thinking about, occasional deep technical posts. No marketing
+fluff.
+
+If you ever want to reply, hit me back at rebekah@kindlyroe.com.
+
+— Rebekah
+```
 
 ### What's wired into the site
 

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -659,7 +659,7 @@
     <span class="subscribe-annotation">&#8627; get notified when new facts are recorded</span>
     <form class="subscribe-form"
           data-kr-subscribe
-          action="https://buttondown.com/api/emails/embed-subscribe/REPLACE_WITH_BUTTONDOWN_USERNAME"
+          action="https://buttondown.com/api/emails/embed-subscribe/Kronroe"
           method="post">
       <input type="email" name="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
       <button type="submit" class="subscribe-btn">Subscribe</button>

--- a/site/blog/why-kronroe/index.html
+++ b/site/blog/why-kronroe/index.html
@@ -725,7 +725,7 @@
       <span class="subscribe-annotation">&#8627; get notified when new facts are recorded</span>
       <form class="subscribe-form"
             data-kr-subscribe
-            action="https://buttondown.com/api/emails/embed-subscribe/REPLACE_WITH_BUTTONDOWN_USERNAME"
+            action="https://buttondown.com/api/emails/embed-subscribe/Kronroe"
             method="post">
         <input type="email" name="email" class="subscribe-input" placeholder="you@example.com" aria-label="Email address" required/>
         <button type="submit" class="subscribe-btn">Subscribe</button>

--- a/site/js/email-capture.js
+++ b/site/js/email-capture.js
@@ -71,15 +71,14 @@
         body: body.toString(),
       })
         .then(function () {
-          submitBtn.disabled = false;
           submitBtn.textContent = 'Subscribed ✓';
-          input.value = '';
           if (statusEl) {
-            statusEl.textContent = 'Thanks — check your inbox to confirm.';
+            statusEl.textContent = 'Redirecting…';
             statusEl.setAttribute('data-state', 'success');
           }
 
-          // GA4 conversion event — gated by consent automatically.
+          // GA4 conversion event — consent-gated; gtag silently drops
+          // if denied. We still want the redirect to happen either way.
           if (typeof window.gtag === 'function') {
             window.gtag('event', 'generate_lead', {
               method: 'newsletter',
@@ -88,10 +87,14 @@
             });
           }
 
-          // Reset button label after a moment so the form feels reusable.
+          // Brief pause gives the GA beacon time to leave before the
+          // redirect kills the page. 600ms covers typical beacon RTT
+          // (50-200ms) with a comfortable buffer. After redirect, the
+          // /newsletter/thanks/ page tells users to check their inbox
+          // and watch for spam — better UX than an inline status.
           setTimeout(function () {
-            submitBtn.textContent = submitBtn.dataset.label || 'Subscribe';
-          }, 4000);
+            window.location.href = '/newsletter/thanks/';
+          }, 600);
         })
         .catch(function (_err) {
           submitBtn.disabled = false;

--- a/site/newsletter/confirmed/index.html
+++ b/site/newsletter/confirmed/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>You're in — welcome to Kronroe Notes</title>
+<meta name="description" content="Subscription confirmed. Welcome to Kronroe Notes."/>
+<meta name="robots" content="noindex"/>
+<link rel="canonical" href="https://kronroe.dev/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<script>
+  // Fire the GA4 conversion event for *confirmed* subscriptions.
+  // Wrapped in a setTimeout so the deferred consent script has time to
+  // load + apply consent state before we push to dataLayer. If consent
+  // was denied, gtag will silently drop the event — that's correct.
+  window.addEventListener('DOMContentLoaded', function () {
+    setTimeout(function () {
+      if (typeof window.gtag === 'function') {
+        window.gtag('event', 'subscribe_confirmed', {
+          method: 'newsletter',
+          currency: 'USD',
+          value: 1, // proxy value — every confirmed subscriber is worth something
+        });
+      }
+    }, 600); // gives consent's wait_for_update (500ms) a chance to settle
+  });
+</script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Virgil';
+    src: url('/fonts/web/virgil.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    min-height: 100vh;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem;
+    text-align: center;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    max-width: 480px;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 2.5rem;
+  }
+
+  .eyebrow {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: var(--lime-6);
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+
+  h1 {
+    font-size: clamp(2.25rem, 6vw, 3.5rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: 1.25rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+    color: var(--warm-7);
+    max-width: 520px;
+    margin: 0 auto 1.5rem;
+  }
+
+  .lede em { font-style: italic; color: var(--warm-10); }
+
+  .annotation {
+    font-family: 'Virgil', 'Caveat', cursive;
+    font-size: 1.05rem;
+    color: var(--copper-6);
+    margin: 0 auto 2.5rem;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 3rem;
+  }
+
+  .btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1.5px solid transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .btn-primary {
+    background: var(--violet-6);
+    color: #fff;
+    border-color: var(--violet-6);
+  }
+  .btn-primary:hover { background: var(--violet-7); border-color: var(--violet-7); }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--warm-7);
+    border-color: #C4BFD1;
+  }
+  .btn-secondary:hover {
+    background: var(--surface);
+    color: var(--warm-10);
+  }
+
+  .promise {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    max-width: 480px;
+    margin: 0 auto;
+    text-align: left;
+    line-height: 1.7;
+  }
+  .promise strong { color: var(--warm-7); font-weight: 600; }
+
+  footer {
+    margin-top: 3rem;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+  }
+  footer a {
+    color: var(--violet-6);
+    text-decoration: none;
+  }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="eyebrow">✓ subscription confirmed</p>
+
+<h1>You're in.</h1>
+
+<p class="lede">
+  Welcome to <em>Kronroe Notes</em>. Build updates land in your inbox
+  every two weeks or so &mdash; what changed in the engine, what I'm
+  thinking about, the occasional deep technical post.
+</p>
+
+<p class="annotation">&#8627; no marketing fluff, just the work</p>
+
+<div class="actions">
+  <a class="btn btn-primary" href="/blog/why-kronroe/">Start with the why</a>
+  <a class="btn btn-secondary" href="/docs/">Browse the docs</a>
+  <a class="btn btn-secondary" href="https://github.com/kronroe/kronroe">Star on GitHub</a>
+</div>
+
+<div class="promise">
+  <strong>What you can expect:</strong> ~26 emails/year, all from
+  rebekah@kindlyroe.com<br>
+  <strong>What you won't get:</strong> sales pitches, list rentals,
+  cross-promotions<br>
+  <strong>Unsubscribe:</strong> one click in any email
+</div>
+
+<footer>
+  <p>&copy; 2026 Kronroe &middot; <a href="https://github.com/kronroe">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/site/newsletter/thanks/index.html
+++ b/site/newsletter/thanks/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Almost there — check your inbox | Kronroe</title>
+<meta name="description" content="We just sent you a confirmation email. Click the link inside to finish subscribing."/>
+<meta name="robots" content="noindex"/>
+<link rel="canonical" href="https://kronroe.dev/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Virgil';
+    src: url('/fonts/web/virgil.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    min-height: 100vh;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem;
+    text-align: center;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    max-width: 480px;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 2.5rem;
+  }
+
+  .eyebrow {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: var(--warm-5);
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: 1.25rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+    color: var(--warm-7);
+    max-width: 480px;
+    margin: 0 auto 1.5rem;
+  }
+
+  .annotation {
+    font-family: 'Virgil', 'Caveat', cursive;
+    font-size: 1.05rem;
+    color: var(--violet-6);
+    margin: 0 auto 2.5rem;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .btn {
+    display: inline-block;
+    padding: 0.7rem 1.4rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1.5px solid transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--warm-7);
+    border-color: #C4BFD1;
+  }
+  .btn-secondary:hover {
+    background: var(--surface);
+    color: var(--warm-10);
+  }
+
+  footer {
+    margin-top: 3rem;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+  }
+  footer a {
+    color: var(--violet-6);
+    text-decoration: none;
+  }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="eyebrow">subscribe — pending confirmation</p>
+
+<h1>Almost there.</h1>
+
+<p class="lede">
+  We just sent a confirmation email to your inbox. Click the link
+  inside to finish subscribing — should arrive within a minute or two.
+</p>
+
+<p class="annotation">&#8627; if it doesn't show up, check spam</p>
+
+<div class="actions">
+  <a class="btn btn-secondary" href="/blog/">Read the blog while you wait</a>
+  <a class="btn btn-secondary" href="/">Back to homepage</a>
+</div>
+
+<footer>
+  <p>&copy; 2026 Kronroe &middot; <a href="https://github.com/kronroe/kronroe">GitHub</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Final piece of the launch-polish trilogy — replaces the placeholder
in the subscribe forms with the real Buttondown endpoint (username
`Kronroe`), updates CSP, and documents the deliberate two-stage
strategy for the newsletter platform.

### What changed (4 files)

| File | Change |
|---|---|
| `site/blog/index.html` | Form `action` → `https://buttondown.com/api/emails/embed-subscribe/Kronroe` |
| `site/blog/why-kronroe/index.html` | Same |
| `firebase.json` | CSP `connect-src` adds `https://buttondown.com` (form POST) and `https://buttondown.email` (asset/tracking-pixel domain) |
| `site/SETUP-EXTERNAL.md` | Full rewrite to capture launch state, document Buttondown→Keila migration plan |

### The strategy in `SETUP-EXTERNAL.md`

We evaluated Buttondown, Keila (managed + self-hosted), Listmonk,
Ghost, Beehiiv, Substack, and GCP-native options. Two real contenders:

- **Keila** is the long-term target — AGPL-3.0 (matches Kronroe), EU
  hosted, self-host migration path. ~€9/mo from day one.
- **Buttondown** is the on-ramp — free up to 100 subscribers, 5-min
  setup, native RSS-to-email automation. £0 ongoing cost until traction
  justifies the spend.

The doc captures **migration triggers** (≥80 subs / ≥500 PyPI dl/mo /
first commercial enquiry / 6+ posts in 3 months) and the **migration
steps** (~30-60 min, mostly DNS+CSP propagation) so the path is
pre-walked when the trigger fires.

### Migration friction is intentionally low

The form handler in `site/js/email-capture.js` (shipped in #178)
sends both `email` and `email_address` body keys side-by-side.
Switching from Buttondown to Keila later is:

```diff
- action="https://buttondown.com/api/emails/embed-subscribe/Kronroe"
+ action="https://keila.io/forms/<id>/submit"

- connect-src ... https://buttondown.com https://buttondown.email;
+ connect-src ... https://keila.io;
```

Plus a CSV export → CSV import. ~30 min total when we're ready.

## Test plan

- [x] All 9 Playwright consent tests still pass (re-ran post-changes)
- [x] Form attaches in preview with the real Buttondown URL (no
      placeholder remaining)
- [x] `email-capture.js` enhances the form (`data-kr-enhanced="1"`)
- [ ] Live deploy: post-deploy smoke test passes
- [ ] Post-merge: visit https://kronroe.dev/blog/why-kronroe/, accept
      cookies, subscribe with a fresh email, confirm:
      - Buttondown confirmation email arrives
      - Welcome email arrives after confirmation
      - Subscriber appears in Buttondown's list
      - GA4 Realtime shows a `generate_lead` event
