### PR TITLE
Redirect Firebase default hostnames to kronroe.dev; fix smoke test

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -88,19 +88,35 @@ jobs:
           PLAYGROUND_URL: ${{ steps.deploy.outputs.details_url }}
         run: |
           set -euo pipefail
-          URL="${PLAYGROUND_URL:-https://kronroe.web.app}"
+
+          # Test the canonical kronroe.dev (what users actually see) instead
+          # of kronroe.web.app — the Firebase default hostname now redirects
+          # to kronroe.dev anyway, but checking the canonical also catches
+          # DNS/CDN issues that a bare-Firebase check would miss.
+          URL="${PLAYGROUND_URL:-https://kronroe.dev}"
           echo "Smoke testing ${URL}"
+
+          # Save body to a temp file rather than piping to grep. With
+          # `set -o pipefail`, `curl ... | grep -q` was failing with exit 141
+          # (SIGPIPE): grep finds the match early and exits, then curl gets
+          # SIGPIPE on its still-open write, and pipefail propagates that
+          # 141 as the pipeline result. Writing to a file avoids the pipe
+          # entirely.
+          BODY_FILE="$(mktemp)"
+          trap 'rm -f "${BODY_FILE}"' EXIT
 
           # Retry loop — Firebase CDN edge nodes may take a few seconds to propagate
           MAX_RETRIES=4
           for i in $(seq 1 $MAX_RETRIES); do
-            HTTP_CODE=$(curl -o /dev/null -sL --compressed -w "%{http_code}" "${URL}")
+            HTTP_CODE="$(curl -sL --compressed -o "${BODY_FILE}" -w '%{http_code}' "${URL}")"
+
             if [ "${HTTP_CODE}" != "200" ]; then
               echo "Attempt ${i}/${MAX_RETRIES}: HTTP ${HTTP_CODE} — retrying in 5s..."
               sleep 5
               continue
             fi
-            if curl -sL --compressed "${URL}" | grep -q "Kronroe"; then
+
+            if grep -q "Kronroe" "${BODY_FILE}"; then
               echo "Smoke test passed on attempt ${i} — HTTP ${HTTP_CODE}"
               {
                 echo "## Post-Deploy Smoke Test"
@@ -111,11 +127,14 @@ jobs:
               } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
+
             echo "Attempt ${i}/${MAX_RETRIES}: HTTP 200 but content not yet propagated — retrying in 5s..."
             sleep 5
           done
 
           echo "ERROR: smoke test failed after ${MAX_RETRIES} attempts" >&2
           echo "Last HTTP code: ${HTTP_CODE}" >&2
-          curl -sL --compressed "${URL}" | head -c 500 >&2
+          echo "First 500 bytes of last response body:" >&2
+          head -c 500 "${BODY_FILE}" >&2
+          echo "" >&2
           exit 1

--- a/site/404.html
+++ b/site/404.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>404 — Lost in time | Kronroe</title>
 <meta name="description" content="That page doesn't exist at this point in time."/>
 <meta name="robots" content="noindex"/>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>Blog — Kronroe</title>
 <meta name="description" content="Thoughts on bi-temporal data, AI agent memory, embedded databases, and building Kronroe."/>
 <meta property="og:title" content="Blog — Kronroe"/>

--- a/site/blog/why-kronroe/index.html
+++ b/site/blog/why-kronroe/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>Why we built Kronroe — Kronroe Blog</title>
 <meta name="description" content="AI agents need memory that understands time. Not a key-value store bolted to a vector database — a purpose-built engine where every fact carries four timestamps."/>
 <meta property="og:title" content="Why we built Kronroe"/>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>Docs — Kronroe</title>
 <meta name="description" content="Kronroe documentation — getting started guides, core concepts, and API reference for the embedded bi-temporal graph database."/>
 <meta property="og:title" content="Docs — Kronroe"/>

--- a/site/index.html
+++ b/site/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>Kronroe — Private Bi-temporal AI Memory</title>
 <meta name="description" content="Kronroe is an embedded bi-temporal graph database for AI agent memory and mobile/edge apps. No server, no cloud, no data risk."/>
 <meta property="og:title" content="Kronroe — Private Bi-temporal AI Memory"/>

--- a/site/newsletter/confirmed/index.html
+++ b/site/newsletter/confirmed/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>You're in — welcome to Kronroe Notes</title>
 <meta name="description" content="Subscription confirmed. Welcome to Kronroe Notes."/>
 <meta name="robots" content="noindex"/>

--- a/site/newsletter/thanks/index.html
+++ b/site/newsletter/thanks/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev — runs synchronously before render to avoid flashing wrong-domain content */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
 <title>Almost there — check your inbox | Kronroe</title>
 <meta name="description" content="We just sent you a confirmation email. Click the link inside to finish subscribing."/>
 <meta name="robots" content="noindex"/>


### PR DESCRIPTION
## Summary

Two related fixes that both stem from Firebase Hosting's behavior of serving identical content at three URLs (`kronroe.web.app`, `kronroe.firebaseapp.com`, `kronroe.dev`) with no native cross-domain redirect support.

## What changed

### 1. Redirect Firebase default hostnames to canonical kronroe.dev

Inline IIFE added to the `<head>` of every public-facing page:

```html
<script>(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
```

- Runs synchronously before render (no flash of wrong-domain content)
- Inert on any hostname except the two Firebase defaults (so localhost / kronroe.dev / Playwright tests are unaffected)
- Applied to all 7 pages: index, blog index, why-kronroe, docs, 404, newsletter/thanks, newsletter/confirmed

**Why this matters**: without it, `kronroe.web.app/<path>` returns 200 with full content for any path. Risks:
- Duplicate-content SEO: Google generally respects `<link rel="canonical">` but Bing is less reliable
- Brand leakage: someone shares `kronroe.web.app/blog/why-kronroe/` in a chat → permanent wrong-domain link
- Anyone landing via Firebase Console links sees the site at the wrong domain with no signal

### 2. Fix post-deploy smoke test

Two bugs causing the smoke test to fail on every deploy since PR #173:

**Bug A — wrong URL.** Default URL was `https://kronroe.web.app` (the Firebase default, not what users actually see). Now defaults to `https://kronroe.dev` — also catches DNS/CDN issues a bare-Firebase check would miss.

**Bug B — SIGPIPE in the grep pipeline.** With `set -o pipefail`:

```
curl -sL --compressed "$URL" | grep -q "Kronroe"
```

`grep -q` exits early on match. `curl` is still writing → gets SIGPIPE → exits 141. `pipefail` propagates 141 as the pipeline result. The `if` sees non-zero and treats it as "no match" — even though the body clearly contains "Kronroe". This is why every deploy since #173 has shown red despite the site working perfectly.

Fix: write body to a temp file, grep against the file. No pipe, no SIGPIPE, also easier to debug if it fails again.

## Test plan

- [x] All 9 Playwright consent tests still pass
- [x] Verified locally: redirect IIFE inert on `localhost` (page renders normally)
- [x] Inline JS validated: `(function(){...})()` syntax-checks; `location.replace` preserves path/query/hash
- [ ] Post-merge: deploy workflow shows **green** for the first time since #173
- [ ] Post-merge: `curl -I https://kronroe.web.app` returns content (the JS redirect is client-side, so the server-side response is unchanged — this is fine, the user-facing redirect happens in the browser before render)
- [ ] Post-merge: visit `https://kronroe.web.app/blog/why-kronroe/` in a real browser → should snap to `https://kronroe.dev/blog/why-kronroe/` with no flash

## What this doesn't fix

The `*.web.app` URLs still respond 200 to `curl` and other non-browser clients (since the redirect is client-side JS). This is acceptable — search engine crawlers run JS for indexing decisions, and any human visitor will get the redirect. If we ever need *server-side* redirect, the proper fix is a Cloud Function with Host-header matching, but that's a much bigger change for marginal incremental benefit.

