### PR TITLE
URGENT: fix broken /js/ deploy + add asset sanity check

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -64,6 +64,10 @@ jobs:
           if [ -d site/newsletter ]; then
             cp -r site/newsletter site/dist/newsletter
           fi
+          # Copy shared JS modules (consent banner, email capture, etc.)
+          if [ -d site/js ]; then
+            cp -r site/js site/dist/js
+          fi
           echo "Assembled site/dist/:"
           ls -la site/dist/
 
@@ -73,6 +77,45 @@ jobs:
           test -f site/dist/index.html || { echo "ERROR: index.html missing from dist"; exit 1; }
           grep -q "Kronroe" site/dist/index.html || { echo "ERROR: index.html missing Kronroe content"; exit 1; }
           echo "Smoke test passed"
+
+      - name: Verify all referenced static assets exist in dist
+        # Prevents the classic "ship a page that references /js/foo.js but
+        # forget to copy site/js/ into site/dist/" bug. Greps every HTML
+        # file in dist for src/href attributes and confirms the referenced
+        # local files exist on disk. Skips external URLs and data: URIs.
+        run: |
+          set -euo pipefail
+          missing=0
+          while IFS= read -r html; do
+            # Pull every local src/href from <script>, <link>, <img> tags
+            while IFS= read -r ref; do
+              # Skip empty, external, or data: refs
+              case "$ref" in
+                ""|http*|//*|data:*|mailto:*|tel:*|\#*) continue ;;
+              esac
+              # Strip query string and fragment for filesystem lookup
+              path="${ref%%\?*}"
+              path="${path%%#*}"
+              # Normalise: leading "/" → relative to dist root
+              case "$path" in
+                /*) full="site/dist${path}" ;;
+                *)  full="$(dirname "$html")/${path}" ;;
+              esac
+              # Directory references (e.g. href="/blog/") map to index.html
+              if [ -d "$full" ]; then
+                full="${full%/}/index.html"
+              fi
+              if [ ! -f "$full" ]; then
+                echo "MISSING: $html references $ref → $full not found"
+                missing=$((missing+1))
+              fi
+            done < <(grep -oE '(src|href)="[^"]+"' "$html" | sed -E 's/^(src|href)="([^"]+)"$/\2/')
+          done < <(find site/dist -name '*.html' -type f)
+          if [ "$missing" -gt 0 ]; then
+            echo "ERROR: $missing referenced asset(s) missing from dist" >&2
+            exit 1
+          fi
+          echo "All referenced static assets present in dist"
 
       - name: Deploy to Firebase Hosting
         id: deploy


### PR DESCRIPTION
## URGENT — production has been silently broken

CC ran the E2E test against production and Phase 1 caught a critical infrastructure failure:

- `https://kronroe.dev/js/analytics-consent.js` → **HTTP 404**
- `https://kronroe.dev/js/email-capture.js` → **HTTP 404**

Both files exist in the repo at `site/js/`. The deploy workflow's "Assemble static site into dist" step explicitly copies `index.html`, `404.html`, `og-image.png`, `site/public/*`, `site/docs/`, `site/blog/`, and `site/newsletter/` — but **never `site/js/`**.

This has been broken since PR #177 introduced `site/js/`. Multiple weeks of broken production.

## What's been silently broken since #177

| Surface | Status |
|---|---|
| `gtag.js` loading | ❌ never loaded → **no GA4 data collected since launch** |
| LinkedIn Insight tag | ❌ never loaded → no demographic data |
| Cookie consent banner | ❌ never shown to any visitor |
| Form's client-side redirect to `/newsletter/thanks/` | ❌ broken (form falls back to Buttondown's `After subscribing` redirect URL, which Rebekah configured to `/newsletter/thanks/` anyway, so the user-visible UX is largely intact) |
| GA4 `generate_lead` event on form submit | ❌ never fired |
| GA4 `subscribe_confirmed` event on `/newsletter/confirmed/` | ❌ never fired |

The privacy implication is benign — no tracking happened, so no consent was needed in practice. But the analytics measurement layer has been a silent zero.

## Why our tests didn't catch it

The Playwright consent suite serves from `site/` directly (port 5180), not from `site/dist/`. Firebase serves from `site/dist/`. **Tests pass against source; deployment happens from artifact.** A page that references `/js/foo.js` from `site/blog/index.html` works fine in tests because `site/js/foo.js` exists in source — but Firebase 404s because `site/dist/js/foo.js` was never copied.

## What this PR does

### Fix 1 — copy `site/js/` into dist

One-line addition to the assemble step:

```yaml
if [ -d site/js ]; then
  cp -r site/js site/dist/js
fi
```

### Fix 2 — post-assemble referenced-asset sanity check

Greps every HTML file in `site/dist/` for `src=/href=` references and confirms each local file exists on disk. Catches the entire class of "forgot to copy a directory" bugs with an explicit error pointing at exactly which file references which missing asset.

**Tested locally**:
- With `site/js/` present: ✅ 0 missing assets
- Without `site/js/` (simulating the bug): ❌ 9 explicit `MISSING:` lines, exit 1

If this check had existed at the time of #177, the deploy would have failed loudly within minutes of merging, and we'd have caught the bug immediately instead of weeks later.

## Test plan

- [x] Sanity check verified to pass with full assembly
- [x] Sanity check verified to fail with `site/js/` removed (9 specific errors)
- [ ] Post-merge: check `https://kronroe.dev/js/analytics-consent.js` returns `Content-Type: application/javascript` with the IIFE source
- [ ] Post-merge: check the consent banner appears on a fresh load of `kronroe.dev`
- [ ] Post-merge: re-run CC's E2E test from Phase 1 — should now pass cleanly through to Phase 5 handoff

## Recommended merge ASAP

This is blocking the launch verification. Please merge as soon as you can — production has been broken for weeks, but every additional minute is a minute of analytics not collected and consent not respected.

