### PR TITLE
Soften email-address claim on /newsletter/confirmed/

### DIFF
--- a/site/newsletter/confirmed/index.html
+++ b/site/newsletter/confirmed/index.html
@@ -217,8 +217,7 @@
 </div>
 
 <div class="promise">
-  <strong>What you can expect:</strong> ~26 emails/year, all from
-  rebekah@kindlyroe.com<br>
+  <strong>What you can expect:</strong> ~26 emails/year, all from Rebekah<br>
   <strong>What you won't get:</strong> sales pitches, list rentals,
   cross-promotions<br>
   <strong>Unsubscribe:</strong> one click in any email


### PR DESCRIPTION
## Summary

One-line copy fix on the post-confirmation landing page. Discovered during E2E test verification.

The promise box previously claimed:

> What you can expect: ~26 emails/year, all from rebekah@kindlyroe.com

But Buttondown's free tier sends from `buttondown.email`-managed domains, not the configured From email. The display name "Rebekah Cole" is correct; the literal address claim was inaccurate.

Soften to:

> What you can expect: ~26 emails/year, all from Rebekah

This is accurate regardless of which sending domain Buttondown uses, reads more personal, and survives a future custom-domain migration without needing another fix.

## Test plan

- [x] Verified locally — page renders correctly with the new copy
- [ ] Post-merge: visit https://kronroe.dev/newsletter/confirmed/ and confirm the line reads "all from Rebekah"

