### PR TITLE
Add /about/, /privacy/, /pricing/ pages + footer wiring

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -64,6 +64,16 @@ jobs:
           if [ -d site/newsletter ]; then
             cp -r site/newsletter site/dist/newsletter
           fi
+          # Copy info pages (about / privacy / pricing)
+          if [ -d site/about ]; then
+            cp -r site/about site/dist/about
+          fi
+          if [ -d site/privacy ]; then
+            cp -r site/privacy site/dist/privacy
+          fi
+          if [ -d site/pricing ]; then
+            cp -r site/pricing site/dist/pricing
+          fi
           # Copy shared JS modules (consent banner, email capture, etc.)
           if [ -d site/js ]; then
             cp -r site/js site/dist/js

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
+<title>About Kronroe — built by Rebekah Cole</title>
+<meta name="description" content="Kronroe is built by one person — Rebekah Cole — as the database engine that AI agent memory and on-device apps actually need. Here's the story behind it."/>
+<meta property="og:title" content="About Kronroe — built by Rebekah Cole"/>
+<meta property="og:description" content="The story behind Kronroe — why a sole maintainer is building an embedded bi-temporal graph database in the open."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://kronroe.dev/about/"/>
+<meta property="og:image" content="https://kronroe.dev/og-image.png"/>
+<link rel="canonical" href="https://kronroe.dev/about/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Virgil';
+    src: url('/fonts/web/virgil.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.7;
+  }
+
+  body { padding: 2.5rem 1.5rem 4rem; }
+
+  .container {
+    max-width: 680px;
+    margin: 0 auto;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 3rem;
+  }
+
+  .nav-back {
+    display: inline-block;
+    margin-bottom: 2rem;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    text-decoration: none;
+  }
+  .nav-back:hover { color: var(--violet-6); }
+
+  .eyebrow {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: var(--warm-5);
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: clamp(2.25rem, 5vw, 3rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    margin-bottom: 1.5rem;
+  }
+
+  .lede {
+    font-size: 1.15rem;
+    color: var(--warm-7);
+    line-height: 1.6;
+    margin-bottom: 2.5rem;
+  }
+
+  .lede em { font-style: italic; color: var(--warm-10); }
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 3rem;
+    margin-bottom: 1rem;
+    letter-spacing: -0.01em;
+  }
+
+  p { margin-bottom: 1.25rem; color: var(--warm-7); font-size: 1rem; }
+
+  p strong { color: var(--warm-10); }
+
+  .annotation {
+    font-family: 'Virgil', 'Caveat', cursive;
+    font-size: 1.05rem;
+    color: var(--copper-6);
+    margin: 0.5rem 0 2rem;
+    padding-left: 1rem;
+    border-left: 2px solid var(--copper-6);
+  }
+
+  .pull-quote {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--warm-10);
+    line-height: 1.5;
+    margin: 2rem 0 2.5rem;
+    padding: 1.5rem 1.75rem;
+    background: var(--surface);
+    border-left: 3px solid var(--violet-6);
+    border-radius: 0 10px 10px 0;
+  }
+
+  ul {
+    margin: 0 0 1.5rem 1.5rem;
+    color: var(--warm-7);
+  }
+  li { margin-bottom: 0.5rem; }
+
+  a {
+    color: var(--violet-6);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  a:hover { color: var(--violet-7); }
+
+  code {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85em;
+    background: var(--surface);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    color: var(--warm-10);
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    margin: 2rem 0 2.5rem;
+  }
+  .stat {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+  }
+  .stat-label {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    margin-bottom: 0.25rem;
+  }
+  .stat-value {
+    font-size: 1rem;
+    color: var(--warm-10);
+    font-weight: 600;
+  }
+
+  .cta-row {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin: 2rem 0 1rem;
+  }
+  .btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1.5px solid transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .btn-primary {
+    background: var(--violet-6);
+    color: #fff;
+    border-color: var(--violet-6);
+  }
+  .btn-primary:hover { background: var(--violet-7); border-color: var(--violet-7); }
+  .btn-secondary {
+    background: transparent;
+    color: var(--warm-7);
+    border-color: #C4BFD1;
+  }
+  .btn-secondary:hover {
+    background: var(--surface);
+    color: var(--warm-10);
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 3rem 0 2rem;
+  }
+
+  footer {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--warm-5);
+  }
+  footer a { color: var(--violet-6); }
+</style>
+</head>
+<body>
+
+<div class="container">
+
+<a href="/" class="nav-back">&larr; Kronroe</a>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="eyebrow">about</p>
+
+<h1>One person. One engine. Built in the open.</h1>
+
+<p class="lede">
+  Kronroe is an embedded bi-temporal graph database for AI agent memory
+  and mobile/edge applications. It's built by <strong>one person</strong>
+  — me, Rebekah Cole — as the database engine that on-device AI memory
+  actually needs.
+</p>
+
+<p class="annotation">&#8627; not an app-layer patch on something that wasn't built for it</p>
+
+<h2>Why I'm building it</h2>
+
+<p>
+  I started Kronroe because I needed it for <strong>Kindly Roe</strong>,
+  my iOS app. Kindly Roe is a private, on-device companion that
+  remembers context across conversations — and it needs memory that
+  understands time. Not just <em>"is this fact true?"</em> but
+  <em>"when was it true, when did we record it, and what did we
+  believe before that?"</em>
+</p>
+
+<p>
+  I tried to build it on top of existing tools first. Vector databases
+  with timestamps glued on. Graph databases requiring a server. Cloud
+  services that wanted my users' data. Each one made the same trade-off:
+  treat temporal evolution as an application concern, not an engine
+  primitive. Each one broke under the weight of real conversational
+  memory after a few weeks.
+</p>
+
+<div class="pull-quote">
+  The more I built, the more I realised the problem deserved a proper
+  engine, not an app-layer patch.
+</div>
+
+<p>
+  So I started writing it myself. In Rust, because I wanted it to run
+  on iOS without a runtime. With a bi-temporal model from the bottom
+  up, because that's what the problem actually requires. Open source,
+  because the only way embedded databases earn trust is by being
+  inspectable.
+</p>
+
+<h2>What it is, in one paragraph</h2>
+
+<p>
+  Kronroe is the <a href="/blog/why-kronroe/">DuckDB of graph databases</a>.
+  Like DuckDB redesigned the embedded relational engine for analytical
+  workloads, Kronroe redesigns the embedded graph engine for temporal
+  knowledge evolution. It runs in your process — no server, no cloud,
+  no data leaves your device. Every fact carries four timestamps
+  (<em>valid_from</em>, <em>valid_to</em>, <em>recorded_at</em>,
+  <em>expired_at</em>) so you can ask not just <em>what's true?</em>
+  but <em>what was true when?</em> and <em>what did we believe at the
+  time?</em>
+</p>
+
+<p>It ships as:</p>
+
+<ul>
+  <li>A <strong>Rust crate</strong> (<code>kronroe</code>) for native applications</li>
+  <li>A <strong>Python package</strong> (<code>kronroe</code>) via PyO3</li>
+  <li>An <strong>iOS framework</strong> (<code>KronroeFFI.xcframework</code>) for Swift apps</li>
+  <li>An <strong>Android library</strong> (JNI + Kotlin) for native Android</li>
+  <li>A <strong>WebAssembly bundle</strong> for browser apps</li>
+  <li>An <strong>MCP server</strong> with 11 tools for AI agents</li>
+</ul>
+
+<p>
+  All from one codebase, one engine, one set of guarantees. No backend
+  to provision, no cloud account to create, no API key to manage.
+</p>
+
+<h2>Who I am</h2>
+
+<p>
+  I'm Rebekah Cole. I'm a software engineer based in the United Kingdom.
+  I'm the sole maintainer of Kronroe and the founder of Kindly Roe.
+  I write code in Rust, Swift, Python, and TypeScript depending on the
+  problem.
+</p>
+
+<p>
+  I've spent the last few years on the intersection of AI agents,
+  on-device privacy, and personal tools. The thing I keep coming back
+  to is that the genuinely useful AI applications — the ones that
+  remember you, that work without an internet connection, that don't
+  require trusting someone else's cloud — share a common bottleneck:
+  the storage layer doesn't take time seriously. Kronroe is my answer
+  to that.
+</p>
+
+<p>
+  I built this in the open because I think it's the only way embedded
+  databases earn trust. The license is <strong>AGPL-3.0 with a
+  commercial option</strong>, so individual developers can use it for
+  free in open-source projects, and companies who don't want to be
+  bound by AGPL can buy a commercial licence.
+</p>
+
+<h2>Where it is right now</h2>
+
+<div class="stats">
+  <div class="stat">
+    <div class="stat-label">Status</div>
+    <div class="stat-value">Phase 0 — public alpha</div>
+  </div>
+  <div class="stat">
+    <div class="stat-label">Targets</div>
+    <div class="stat-value">Rust, Python, iOS, Android, WASM, MCP</div>
+  </div>
+  <div class="stat">
+    <div class="stat-label">License</div>
+    <div class="stat-value">AGPL-3.0 + commercial</div>
+  </div>
+  <div class="stat">
+    <div class="stat-label">Maintainer</div>
+    <div class="stat-value">Rebekah Cole (UK)</div>
+  </div>
+</div>
+
+<p>
+  The core engine, MCP server, and platform bindings are all working.
+  The full-text search (Kronroe's own lexical engine), vector index
+  (flat cosine), and contradiction detection are shipping. Hybrid
+  retrieval and the uncertainty model are behind feature flags while
+  I tune them.
+</p>
+
+<p>
+  The first user is <a href="https://github.com/kronroe/kronroe">Kronroe
+  itself, built into Kindly Roe</a>. The second will be you, if you
+  want to try it.
+</p>
+
+<h2>How to follow along</h2>
+
+<p>
+  I share build notes through <strong>Kronroe Notes</strong> — a
+  newsletter that lands roughly every two weeks. Technical decisions,
+  what changed in the engine, what I'm thinking about, the occasional
+  deep technical post. <em>No marketing fluff, just the work.</em>
+</p>
+
+<p>You can also:</p>
+
+<ul>
+  <li>Read the <a href="/blog/">blog</a> (long-form posts)</li>
+  <li>Browse the <a href="/docs/">docs</a></li>
+  <li>Star the project on <a href="https://github.com/kronroe/kronroe">GitHub</a></li>
+  <li>Email me directly at <a href="mailto:rebekah@kindlyroe.com">rebekah@kindlyroe.com</a> — I read everything</li>
+</ul>
+
+<div class="cta-row">
+  <a class="btn btn-primary" href="/blog/why-kronroe/">Start with the why</a>
+  <a class="btn btn-secondary" href="/blog/">Read the blog</a>
+  <a class="btn btn-secondary" href="https://github.com/kronroe/kronroe">Browse GitHub</a>
+</div>
+
+<hr>
+
+<footer>
+  <p>
+    &copy; 2026 Rebekah Cole &middot;
+    <a href="/">Home</a> &middot;
+    <a href="/blog/">Blog</a> &middot;
+    <a href="/docs/">Docs</a> &middot;
+    <a href="/privacy/">Privacy</a> &middot;
+    <a href="https://github.com/kronroe/kronroe">GitHub</a>
+  </p>
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -714,6 +714,9 @@
         <li><a href="https://github.com/kronroe/kronroe/blob/main/LICENCE-COMMERCIAL.md" target="_blank" rel="noopener noreferrer">Commercial Licence</a></li>
         <li><a href="mailto:rebekah@kindlyroe.com">Contact</a></li>
         <li><a href="https://github.com/kronroe/kronroe/blob/main/CLA.md" target="_blank" rel="noopener noreferrer">CLA</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/pricing/">Pricing</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
         <li><a href="#" onclick="event.preventDefault(); window.kronroeConsent &amp;&amp; window.kronroeConsent.open();">Cookie preferences</a></li>
       </ul>
     </div>

--- a/site/blog/why-kronroe/index.html
+++ b/site/blog/why-kronroe/index.html
@@ -781,6 +781,9 @@
         <li><a href="https://github.com/kronroe/kronroe/blob/main/LICENCE-COMMERCIAL.md" target="_blank" rel="noopener noreferrer">Commercial Licence</a></li>
         <li><a href="mailto:rebekah@kindlyroe.com">Contact</a></li>
         <li><a href="https://github.com/kronroe/kronroe/blob/main/CLA.md" target="_blank" rel="noopener noreferrer">CLA</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/pricing/">Pricing</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
         <li><a href="#" onclick="event.preventDefault(); window.kronroeConsent &amp;&amp; window.kronroeConsent.open();">Cookie preferences</a></li>
       </ul>
     </div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -558,6 +558,9 @@
         <li><a href="https://github.com/kronroe/kronroe/blob/main/LICENCE-COMMERCIAL.md">Commercial Licence</a></li>
         <li><a href="mailto:rebekah@kindlyroe.com">Contact</a></li>
         <li><a href="https://github.com/kronroe/kronroe/blob/main/CLA.md">CLA</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/pricing/">Pricing</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
         <li><a href="#" onclick="event.preventDefault(); window.kronroeConsent &amp;&amp; window.kronroeConsent.open();">Cookie preferences</a></li>
       </ul>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -2583,14 +2583,16 @@ function switchCodeTab(tab) {
         <li><a href="https://crates.io/crates/kronroe">Rust Crate</a></li>
         <li><a href="https://pypi.org/project/kronroe/">Python Package</a></li>
         <li><a href="https://github.com/kronroe/kronroe">GitHub</a></li>
+        <li><a href="https://github.com/kronroe/kronroe/blob/main/CLA.md">CLA</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h5>Company</h5>
       <ul>
-        <li><a href="https://github.com/kronroe/kronroe/blob/main/LICENCE-COMMERCIAL.md">Commercial Licence</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/pricing/">Pricing</a></li>
         <li><a href="mailto:rebekah@kindlyroe.com">Contact</a></li>
-        <li><a href="https://github.com/kronroe/kronroe/blob/main/CLA.md">CLA</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
         <li><a href="#" onclick="event.preventDefault(); window.kronroeConsent &amp;&amp; window.kronroeConsent.open();">Cookie preferences</a></li>
       </ul>
     </div>

--- a/site/pricing/index.html
+++ b/site/pricing/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
+<title>Pricing — Kronroe</title>
+<meta name="description" content="Kronroe is dual-licensed under AGPL-3.0 and a commercial licence. Commercial pricing is in development — get in touch for early conversations."/>
+<meta property="og:title" content="Pricing — Kronroe"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://kronroe.dev/pricing/"/>
+<link rel="canonical" href="https://kronroe.dev/pricing/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.65;
+  }
+
+  body { padding: 2.5rem 1.5rem 4rem; }
+
+  .container {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 3rem;
+  }
+
+  .nav-back {
+    display: inline-block;
+    margin-bottom: 2rem;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    text-decoration: none;
+  }
+  .nav-back:hover { color: var(--violet-6); }
+
+  .eyebrow {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: var(--warm-5);
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: 1.5rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+    color: var(--warm-7);
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+  }
+
+  p { margin-bottom: 1rem; color: var(--warm-7); font-size: 0.95rem; }
+
+  ul { margin: 0 0 1rem 1.5rem; color: var(--warm-7); font-size: 0.95rem; }
+  li { margin-bottom: 0.5rem; }
+
+  a { color: var(--violet-6); text-decoration: underline; text-underline-offset: 2px; }
+  a:hover { color: var(--violet-7); }
+
+  code {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85em;
+    background: var(--surface);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    color: var(--warm-10);
+  }
+
+  .tier-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin: 2rem 0;
+  }
+  @media (max-width: 600px) { .tier-grid { grid-template-columns: 1fr; } }
+
+  .tier {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem 1.5rem 1.75rem;
+    position: relative;
+  }
+  .tier::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    border-radius: 12px 12px 0 0;
+  }
+  .tier-open::before { background: var(--lime-6); }
+  .tier-commercial::before { background: var(--violet-6); }
+
+  .tier-name {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+  .tier-headline {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--warm-10);
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.01em;
+  }
+  .tier-price {
+    font-size: 0.92rem;
+    color: var(--warm-7);
+    margin-bottom: 1rem;
+  }
+  .tier-price strong { color: var(--warm-10); font-weight: 600; }
+  .tier ul { margin: 0 0 0 1.25rem; font-size: 0.88rem; }
+  .tier li { margin-bottom: 0.4rem; }
+
+  .cta-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2rem 2rem 2rem;
+    text-align: center;
+    margin: 3rem 0 1rem;
+    position: relative;
+  }
+  .cta-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 12px 12px 0 0;
+  }
+  .cta-card h3 {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+  }
+  .cta-card p { font-size: 0.9rem; max-width: 440px; margin: 0 auto 1.25rem; }
+
+  .btn {
+    display: inline-block;
+    padding: 0.7rem 1.5rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1.5px solid transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .btn-primary {
+    background: var(--violet-6);
+    color: #fff;
+    border-color: var(--violet-6);
+  }
+  .btn-primary:hover { background: var(--violet-7); border-color: var(--violet-7); }
+
+  hr { border: none; border-top: 1px solid var(--border); margin: 3rem 0 2rem; }
+
+  footer {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--warm-5);
+  }
+  footer a { color: var(--violet-6); }
+</style>
+</head>
+<body>
+
+<div class="container">
+
+<a href="/" class="nav-back">&larr; Kronroe</a>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="eyebrow">pricing</p>
+
+<h1>Free for open source. Commercial licence in development.</h1>
+
+<p class="lede">
+  Kronroe is dual-licensed under <strong>AGPL-3.0</strong> for open-source
+  use and a <strong>commercial licence</strong> for companies that need
+  different terms. Commercial pricing is being designed deliberately — so
+  rather than guess, this page is honest about where it stands today.
+</p>
+
+<div class="tier-grid">
+  <div class="tier tier-open">
+    <p class="tier-name">Open source</p>
+    <h2 class="tier-headline">AGPL-3.0</h2>
+    <p class="tier-price"><strong>Free.</strong> Forever.</p>
+    <ul>
+      <li>Full engine, all platforms (Rust, Python, iOS, Android, WASM, MCP)</li>
+      <li>All current and future features</li>
+      <li>No usage limits, no telemetry, no lock-in</li>
+      <li>Your project must also be open-source under a compatible licence</li>
+      <li>Full source on <a href="https://github.com/kronroe/kronroe">GitHub</a></li>
+    </ul>
+  </div>
+  <div class="tier tier-commercial">
+    <p class="tier-name">Commercial</p>
+    <h2 class="tier-headline">Talk to us</h2>
+    <p class="tier-price"><strong>Pricing in development.</strong></p>
+    <ul>
+      <li>Use Kronroe in proprietary or closed-source products</li>
+      <li>Distribute it embedded in commercial software</li>
+      <li>No AGPL obligations on your application code</li>
+      <li>Same engine, same updates, same support direction</li>
+      <li>Get in touch for early conversations</li>
+    </ul>
+  </div>
+</div>
+
+<h2>Why pricing isn't public yet</h2>
+
+<p>
+  I'm a sole maintainer building this in public. Setting commercial
+  pricing too early — before there are enough commercial conversations
+  to know what's reasonable — leads to numbers that are either too high
+  (and lose deals) or too low (and damage long-term sustainability).
+</p>
+
+<p>
+  So instead of putting up a number that I'd have to defend or change,
+  I'd rather talk. Most early commercial users want a few specific
+  things — perpetual licence vs. subscription, single-product vs.
+  organisation-wide, distribution rights vs. internal use — and the
+  right price depends on which combination matches your situation.
+</p>
+
+<h2>What's available right now</h2>
+
+<ul>
+  <li>
+    <strong>If you're building open-source software</strong> compatible
+    with <a href="https://github.com/kronroe/kronroe/blob/main/LICENSE">AGPL-3.0</a>,
+    you can use Kronroe today, free, with no further conversation needed.
+  </li>
+  <li>
+    <strong>If you're building commercial software</strong> and need
+    different terms,
+    <a href="mailto:rebekah@kindlyroe.com?subject=Kronroe%20commercial%20licence">email me</a>.
+    We'll work out a licence that makes sense for your situation. Early
+    customers get founder pricing.
+  </li>
+  <li>
+    <strong>If you're not sure</strong> which applies to you, also email
+    me. AGPL is genuinely viral in some software designs and benign in
+    others, and a 5-minute conversation usually clarifies it.
+  </li>
+</ul>
+
+<h2>What you can expect when pricing lands</h2>
+
+<p>
+  When the commercial pricing is published, it'll likely follow this
+  shape:
+</p>
+
+<ul>
+  <li>A <strong>per-product perpetual licence</strong> for shipping
+  Kronroe embedded in a commercial application</li>
+  <li>An <strong>organisation-wide annual subscription</strong> for
+  internal use across multiple products</li>
+  <li><strong>OEM pricing</strong> for distributing Kronroe inside other
+  developer-facing tools</li>
+  <li><strong>Founder pricing for early customers</strong> who agree to
+  multi-year terms before the public price ships</li>
+</ul>
+
+<p>
+  Existing licensees won't have their terms increased retroactively when
+  public pricing arrives. The
+  <a href="https://github.com/kronroe/kronroe/blob/main/LICENCE-COMMERCIAL.md">commercial licence text</a>
+  already exists; only the price is in flux.
+</p>
+
+<div class="cta-card">
+  <h3>Want a commercial licence?</h3>
+  <p>
+    Tell me what you're building and what shape of licence would work.
+    Most early conversations close in a week or two, with founder pricing
+    that beats whatever the public number ends up being.
+  </p>
+  <a class="btn btn-primary" href="mailto:rebekah@kindlyroe.com?subject=Kronroe%20commercial%20licence">Email Rebekah</a>
+</div>
+
+<hr>
+
+<footer>
+  <p>
+    &copy; 2026 Rebekah Cole &middot;
+    <a href="/">Home</a> &middot;
+    <a href="/about/">About</a> &middot;
+    <a href="/privacy/">Privacy</a> &middot;
+    <a href="https://github.com/kronroe/kronroe">GitHub</a>
+  </p>
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<script>/* Redirect Firebase default hostnames to canonical kronroe.dev */
+(function(){var h=location.hostname;if(h==='kronroe.web.app'||h==='kronroe.firebaseapp.com'){location.replace('https://kronroe.dev'+location.pathname+location.search+location.hash);}})();</script>
+<title>Privacy &amp; Cookies | Kronroe</title>
+<meta name="description" content="How Kronroe handles personal data, cookies, and analytics. Plain-English version, with the legally precise version where it matters."/>
+<meta property="og:title" content="Privacy &amp; Cookies | Kronroe"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://kronroe.dev/privacy/"/>
+<link rel="canonical" href="https://kronroe.dev/privacy/"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<script defer src="/js/analytics-consent.js"></script>
+<style>
+  @font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('/fonts/web/plusjakartasans-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains Mono';
+    src: url('/fonts/web/jetbrainsmono-var-latin.woff2') format('woff2');
+    font-weight: 400 700;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root {
+    --bg: #FBFAFF;
+    --warm-10: #191726;
+    --warm-7: #4A4559;
+    --warm-5: #6E6980;
+    --violet-6: #7C5CFC;
+    --violet-7: #6344E0;
+    --copper-6: #E87D4A;
+    --cyan-6: #3EC9C9;
+    --lime-6: #8BBF20;
+    --border: #DDD9E8;
+    --surface: #F4F2FA;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--warm-10);
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    line-height: 1.65;
+  }
+
+  body { padding: 2.5rem 1.5rem 4rem; }
+
+  .container {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  .stripe {
+    height: 4px;
+    width: 100%;
+    background: linear-gradient(90deg,
+      var(--violet-6) 0 25%,
+      var(--copper-6) 25% 50%,
+      var(--cyan-6) 50% 75%,
+      var(--lime-6) 75% 100%);
+    border-radius: 2px;
+    margin-bottom: 3rem;
+  }
+
+  .meta {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    color: var(--warm-5);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 1rem;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: 1rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+    color: var(--warm-7);
+    margin-bottom: 2.5rem;
+  }
+
+  h2 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin-top: 3rem;
+    margin-bottom: 1rem;
+    scroll-margin-top: 1rem;
+  }
+
+  h3 {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: var(--warm-7);
+  }
+
+  p { margin-bottom: 1rem; color: var(--warm-7); font-size: 0.95rem; }
+
+  ul, ol {
+    margin: 0 0 1rem 1.5rem;
+    color: var(--warm-7);
+    font-size: 0.95rem;
+  }
+  li { margin-bottom: 0.5rem; }
+
+  a {
+    color: var(--violet-6);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  a:hover { color: var(--violet-7); }
+
+  code {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85em;
+    background: var(--surface);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    color: var(--warm-10);
+  }
+
+  .toc {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    margin: 2rem 0 3rem;
+    font-size: 0.88rem;
+  }
+  .toc strong {
+    display: block;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+  }
+  .toc ul { list-style: none; margin: 0; }
+  .toc li { margin-bottom: 0.25rem; }
+  .toc a { color: var(--warm-7); text-decoration: none; }
+  .toc a:hover { color: var(--violet-6); text-decoration: underline; }
+
+  .summary-box {
+    background: var(--surface);
+    border-left: 3px solid var(--violet-6);
+    padding: 1rem 1.25rem;
+    margin: 1.5rem 0;
+    font-size: 0.9rem;
+  }
+  .summary-box strong { color: var(--violet-7); }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0 1.5rem;
+    font-size: 0.88rem;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  th {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--warm-5);
+    font-weight: 600;
+    background: var(--surface);
+  }
+  td code { font-size: 0.78rem; }
+
+  .nav-back {
+    display: inline-block;
+    margin-bottom: 2rem;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--warm-5);
+    text-decoration: none;
+  }
+  .nav-back:hover { color: var(--violet-6); }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 3rem 0 2rem;
+  }
+
+  footer {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--warm-5);
+  }
+  footer a { color: var(--violet-6); }
+</style>
+</head>
+<body>
+
+<div class="container">
+
+<a href="/" class="nav-back">&larr; Kronroe</a>
+
+<div class="stripe" aria-hidden="true"></div>
+
+<p class="meta">Last updated: 27 April 2026 &middot; v1.0</p>
+
+<h1>Privacy &amp; cookies</h1>
+
+<p class="lede">
+  Plain-English version, with the legally precise version where it matters.
+  Kronroe is built by one person — Rebekah Cole — and the data practices
+  here reflect that: what's collected is collected because something
+  genuinely needs it, not because someone built an analytics pipeline by
+  default.
+</p>
+
+<div class="toc">
+  <strong>Contents</strong>
+  <ul>
+    <li><a href="#summary">1. The short version</a></li>
+    <li><a href="#who">2. Who we are</a></li>
+    <li><a href="#data">3. What data we collect</a></li>
+    <li><a href="#why">4. Why we collect it (legal basis)</a></li>
+    <li><a href="#third-parties">5. Who we share it with</a></li>
+    <li><a href="#cookies">6. Cookies</a></li>
+    <li><a href="#retention">7. How long we keep it</a></li>
+    <li><a href="#rights">8. Your rights</a></li>
+    <li><a href="#international">9. International transfers</a></li>
+    <li><a href="#children">10. Children</a></li>
+    <li><a href="#changes">11. Changes to this policy</a></li>
+    <li><a href="#contact">12. Contact &amp; complaints</a></li>
+  </ul>
+</div>
+
+<h2 id="summary">1. The short version</h2>
+
+<div class="summary-box">
+  <p><strong>If you don't accept cookies:</strong> we collect nothing analytics-related. We don't see who you are, what page you read, or where you came from. Site functionality (loading pages, reading the blog, subscribing to the newsletter) all still works.</p>
+  <p><strong>If you accept analytics cookies:</strong> Google Analytics 4 collects anonymous usage data — pages viewed, traffic sources, rough geography — to help us understand how the site is used.</p>
+  <p><strong>If you accept marketing cookies:</strong> the LinkedIn Insight Tag collects anonymous professional demographic data (job titles, industries) to help us understand our audience.</p>
+  <p><strong>If you subscribe to the newsletter:</strong> your email address goes to Buttondown, our newsletter provider. You can unsubscribe with one click in any email.</p>
+  <p style="margin-bottom:0"><strong>We don't sell, rent, or share data with anyone outside the providers named here.</strong></p>
+</div>
+
+<h2 id="who">2. Who we are</h2>
+
+<p>
+  Kronroe is operated by Rebekah Cole, sole proprietor, based in the
+  United Kingdom. For the purposes of UK GDPR and EU GDPR, Rebekah Cole
+  is the <strong>data controller</strong> for personal data collected
+  through this website.
+</p>
+
+<p>
+  <strong>Contact:</strong> <a href="mailto:rebekah@kindlyroe.com">rebekah@kindlyroe.com</a><br>
+  <strong>Website:</strong> <a href="https://kronroe.dev">kronroe.dev</a>
+</p>
+
+<h2 id="data">3. What data we collect</h2>
+
+<p>The categories of personal data we collect are:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>What's in it</th>
+      <th>When collected</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Newsletter subscriber data</td>
+      <td>Your email address; date you subscribed; date you confirmed; date you unsubscribed (if applicable); a record of consent.</td>
+      <td>Only when you subscribe via a form on this site.</td>
+    </tr>
+    <tr>
+      <td>Cookie consent record</td>
+      <td>Your consent choices (analytics yes/no, marketing yes/no), the version of this policy you consented to, the date you chose, and the date that consent expires (12 months).</td>
+      <td>When you make a choice in the cookie banner. Stored in a cookie on your own device.</td>
+    </tr>
+    <tr>
+      <td>Analytics data (with consent)</td>
+      <td>Anonymous Google Analytics 4 data: pages viewed, time on page, traffic source, browser, rough geography (city level), device type. <strong>No personal identifiers.</strong></td>
+      <td>Only after you accept analytics cookies.</td>
+    </tr>
+    <tr>
+      <td>Marketing data (with consent)</td>
+      <td>Anonymous LinkedIn Insight Tag data: aggregate professional demographics of site visitors (job titles, industries). <strong>No personal identifiers visible to us.</strong></td>
+      <td>Only after you accept marketing cookies.</td>
+    </tr>
+    <tr>
+      <td>Server logs</td>
+      <td>Standard web server logs (IP address, requested URL, timestamp, user agent). Retained briefly by our hosting provider for security and operational purposes.</td>
+      <td>On every request, before any consent decision. Required for the site to function.</td>
+    </tr>
+    <tr>
+      <td>Email correspondence</td>
+      <td>If you email us, we keep that email and our reply.</td>
+      <td>When you email us.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="why">4. Why we collect it (legal basis)</h2>
+
+<p>Under UK and EU GDPR, every piece of personal data we process must have a legal basis. Here are ours:</p>
+
+<ul>
+  <li><strong>Newsletter subscriber data:</strong> Consent (Article 6(1)(a) UK/EU GDPR). You actively chose to subscribe; you can withdraw consent at any time by unsubscribing.</li>
+  <li><strong>Cookie consent record:</strong> Legitimate interest in keeping a record of your consent choices (Article 6(1)(f)). Required by GDPR's accountability principle — without it, we couldn't prove you'd given consent.</li>
+  <li><strong>Analytics &amp; marketing data:</strong> Consent (Article 6(1)(a)). No analytics or marketing data is collected unless you actively accept the relevant cookie category.</li>
+  <li><strong>Server logs:</strong> Legitimate interest in operating, securing, and debugging the website (Article 6(1)(f)).</li>
+  <li><strong>Email correspondence:</strong> Legitimate interest in responding to you (Article 6(1)(f)) and contractual necessity if you've engaged us commercially.</li>
+</ul>
+
+<h2 id="third-parties">5. Who we share it with</h2>
+
+<p>We share data with the following service providers, only as needed for the named purpose:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Provider</th>
+      <th>Purpose</th>
+      <th>Data shared</th>
+      <th>Where it's processed</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://buttondown.com/privacy" target="_blank" rel="noopener">Buttondown</a></td>
+      <td>Newsletter delivery</td>
+      <td>Email address; subscription metadata</td>
+      <td>USA</td>
+    </tr>
+    <tr>
+      <td><a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google (Analytics 4)</a></td>
+      <td>Anonymous usage analytics (consent-gated)</td>
+      <td>IP address (anonymised), browser, page views</td>
+      <td>USA / EU</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.linkedin.com/legal/privacy-policy" target="_blank" rel="noopener">LinkedIn (Insight Tag)</a></td>
+      <td>Anonymous demographic analytics (consent-gated)</td>
+      <td>Browser cookies; aggregate visitor data</td>
+      <td>USA / EU</td>
+    </tr>
+    <tr>
+      <td><a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Google Firebase Hosting</a></td>
+      <td>Website hosting</td>
+      <td>Server logs (IP, request)</td>
+      <td>USA / global CDN</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <strong>We do not sell or rent your data to anyone.</strong>
+  We never share data with advertisers, brokers, or other third parties
+  beyond the operational providers above. The named providers are
+  contractually bound to use your data only as needed to perform their
+  service for us.
+</p>
+
+<h2 id="cookies">6. Cookies</h2>
+
+<p>
+  This site uses three categories of cookies. You're shown a banner on
+  your first visit and can change your choices any time via the
+  <strong>Cookie preferences</strong> link in the footer of every page.
+</p>
+
+<h3>6.1 Necessary cookies</h3>
+<p>
+  These keep the site working. They can't be disabled because the site
+  wouldn't function without them.
+</p>
+<table>
+  <thead>
+    <tr>
+      <th>Cookie</th>
+      <th>Purpose</th>
+      <th>Duration</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>kronroe_consent</code></td>
+      <td>Stores your consent choices (which categories you accepted) plus the policy version and timestamps. Required by GDPR's accountability principle.</td>
+      <td>12 months</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>6.2 Analytics cookies (consent-gated)</h3>
+<p>Set only after you accept analytics. Used to understand how the site is used.</p>
+<table>
+  <thead>
+    <tr>
+      <th>Cookie</th>
+      <th>Provider</th>
+      <th>Purpose</th>
+      <th>Duration</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>_ga</code>, <code>_ga_*</code></td>
+      <td>Google Analytics 4</td>
+      <td>Distinguishes unique visitors (anonymous)</td>
+      <td>2 years</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>6.3 Marketing cookies (consent-gated)</h3>
+<p>Set only after you accept marketing. Used to understand audience demographics.</p>
+<table>
+  <thead>
+    <tr>
+      <th>Cookie</th>
+      <th>Provider</th>
+      <th>Purpose</th>
+      <th>Duration</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>li_sugr</code>, <code>UserMatchHistory</code>, <code>AnalyticsSyncHistory</code>, <code>bcookie</code>, <code>lidc</code>, <code>ln_or</code></td>
+      <td>LinkedIn Insight Tag</td>
+      <td>Anonymous professional demographic measurement</td>
+      <td>3-90 days</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  When you reject a cookie category or withdraw consent, we use Google
+  Consent Mode v2 to tell Google immediately to stop collecting
+  analytics data for you, and we don't load the LinkedIn Insight Tag
+  at all if marketing was rejected.
+</p>
+
+<h2 id="retention">7. How long we keep it</h2>
+
+<ul>
+  <li><strong>Newsletter data:</strong> Until you unsubscribe, plus a short retention period afterward (so we don't accidentally re-add you). You can request immediate erasure at any time.</li>
+  <li><strong>Cookie consent record:</strong> 12 months in the cookie itself. After expiry, you'll be re-prompted on your next visit.</li>
+  <li><strong>Analytics data:</strong> Configured to Google's standard 14-month retention. Aggregated reports persist longer but contain no personal data.</li>
+  <li><strong>Server logs:</strong> Per Firebase Hosting's standard retention (typically days to weeks for operational logs).</li>
+  <li><strong>Email correspondence:</strong> Kept for as long as the relationship is active or there's a legitimate reason to retain it. Generally up to 3 years for support correspondence.</li>
+</ul>
+
+<h2 id="rights">8. Your rights</h2>
+
+<p>
+  Under UK and EU GDPR, you have the following rights regarding your
+  personal data:
+</p>
+
+<ul>
+  <li><strong>Right of access:</strong> ask for a copy of the personal data we hold about you.</li>
+  <li><strong>Right to rectification:</strong> ask us to correct inaccurate data.</li>
+  <li><strong>Right to erasure ("right to be forgotten"):</strong> ask us to delete your data, subject to limited exceptions.</li>
+  <li><strong>Right to restrict processing:</strong> ask us to pause processing while a query is resolved.</li>
+  <li><strong>Right to data portability:</strong> receive your data in a structured, machine-readable format.</li>
+  <li><strong>Right to object:</strong> object to processing based on legitimate interests, including direct marketing.</li>
+  <li><strong>Right to withdraw consent:</strong> at any time, where processing is based on consent.</li>
+  <li><strong>Rights in relation to automated decision-making:</strong> we don't make automated decisions about you with legal or significant effects, so this generally doesn't apply.</li>
+</ul>
+
+<p>
+  To exercise any of these rights, email <a href="mailto:rebekah@kindlyroe.com">rebekah@kindlyroe.com</a>.
+  We aim to respond within 30 days. There's no charge.
+</p>
+
+<p>
+  If you're unhappy with how we've handled your data, you have the
+  right to lodge a complaint with the
+  <a href="https://ico.org.uk" target="_blank" rel="noopener">UK Information Commissioner's Office (ICO)</a>
+  or the data protection authority in your country.
+</p>
+
+<h2 id="international">9. International transfers</h2>
+
+<p>
+  Some of our service providers (Buttondown, Google, LinkedIn) are
+  based in the United States. Where data is transferred outside the
+  UK/EU, we rely on the relevant lawful transfer mechanism:
+</p>
+<ul>
+  <li>The UK and EU adequacy decisions (where they apply)</li>
+  <li>Standard Contractual Clauses for transfers where adequacy doesn't apply</li>
+  <li>The provider's own GDPR-compliant transfer framework</li>
+</ul>
+
+<h2 id="children">10. Children</h2>
+
+<p>
+  Kronroe is a developer tool aimed at adults. We don't knowingly
+  collect personal data from anyone under 16. If you believe a child
+  has subscribed to our newsletter, email
+  <a href="mailto:rebekah@kindlyroe.com">rebekah@kindlyroe.com</a> and
+  we'll delete the record promptly.
+</p>
+
+<h2 id="changes">11. Changes to this policy</h2>
+
+<p>
+  When we make material changes to this policy (changing what data we
+  collect, who it's shared with, or how it's used), we increment the
+  policy version. Your previously-recorded consent automatically becomes
+  invalid and you'll be prompted to re-consent on your next visit.
+</p>
+
+<p>
+  Minor changes (clarifying wording, fixing typos) update the
+  "Last updated" date but don't trigger re-consent.
+</p>
+
+<h2 id="contact">12. Contact &amp; complaints</h2>
+
+<p>
+  Questions, concerns, or rights requests:
+  <a href="mailto:rebekah@kindlyroe.com">rebekah@kindlyroe.com</a>.
+</p>
+
+<p>
+  ICO complaints (UK):
+  <a href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener">ico.org.uk/make-a-complaint</a>.
+</p>
+
+<hr>
+
+<footer>
+  <p>
+    &copy; 2026 Rebekah Cole &middot; Kronroe is dual-licensed under
+    AGPL-3.0 and a commercial licence &middot;
+    <a href="/">Home</a> &middot;
+    <a href="/about/">About</a> &middot;
+    <a href="https://github.com/kronroe/kronroe">GitHub</a>
+  </p>
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -19,6 +19,24 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://kronroe.dev/about/</loc>
+    <lastmod>2026-04-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://kronroe.dev/pricing/</loc>
+    <lastmod>2026-04-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://kronroe.dev/privacy/</loc>
+    <lastmod>2026-04-27</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://kronroe.dev/blog/why-kronroe/</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>

--- a/site/scripts/build-sitemap.py
+++ b/site/scripts/build-sitemap.py
@@ -38,6 +38,9 @@ STATIC_PAGES = [
     {"loc": "/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "1.0"},
     {"loc": "/docs/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "0.9"},
     {"loc": "/blog/", "lastmod": "2026-04-13", "changefreq": "weekly", "priority": "0.8"},
+    {"loc": "/about/", "lastmod": "2026-04-27", "changefreq": "monthly", "priority": "0.7"},
+    {"loc": "/pricing/", "lastmod": "2026-04-27", "changefreq": "monthly", "priority": "0.7"},
+    {"loc": "/privacy/", "lastmod": "2026-04-27", "changefreq": "yearly", "priority": "0.4"},
 ]
 
 PUBLISHED_TIME_RE = re.compile(


### PR DESCRIPTION
## Summary

Three new info pages plus connective tissue. Closes the "legally required + high-conversion" gaps in the site structure.

| Page | Purpose | Time-to-build |
|---|---|---|
| `/privacy/` | UK/EU GDPR + PECR compliance — plain-English, ICO style | ~2 hr |
| `/about/` | Founder + project story — highest-conversion surface for a sole-maintainer indie product | ~2 hr |
| `/pricing/` | Honest "commercial pricing in development" placeholder + tier comparison | ~30 min |

## Why each

### Privacy is legally urgent

GA4 + LinkedIn Insight Tag tracking visitors triggers UK GDPR and PECR requirements for a public, accessible privacy policy. Without one, the consent banner is just window dressing — the underlying legal duty is to *also* publish what's collected, who gets it, and how to exercise rights. ICO complaints are real. This closes that gap.

### About is the conversion gap

For a sole-maintainer indie product, the founder story page converts at 3-5x other surfaces. Visitors who care enough to read about the project want to know who's behind it. Right now they see "© 2026 Kronroe" in the footer and have to figure it out from the blog. The new `/about/` makes the story discoverable in one click.

### Pricing is honest signaling

A "pricing — coming soon" page is a real expression of intent: it tells visitors that commercial use is on the table, gives them a path to start the conversation, and signals professionalism. Hiding pricing entirely reads as either "we haven't thought about it" or "we don't want commercial users." Neither is true.

## What's in each

### `/privacy/`

- Plain-English structure, ICO-aligned
- Identity of data controller (Rebekah Cole, UK)
- 6 data categories with what/when/why for each
- Legal bases per Article 6(1)(a) and 6(1)(f)
- Third parties: Buttondown, Google, LinkedIn, Firebase — each linked to their own policies
- `/privacy/#cookies` anchor with all cookie names + durations
- All 8 GDPR rights + how to exercise them
- ICO complaint link
- International transfers mechanism (SCCs + adequacy)
- Children's policy (16+)
- Versioning behavior (material changes invalidate consent + re-prompt)
- Last-updated date

### `/about/`

- Headline: *"One person. One engine. Built in the open."*
- Why Kronroe was built (Kindly Roe drove it; existing tools failed)
- What it is in one paragraph (DuckDB analogy)
- Six platforms shipped from one engine
- Who Rebekah is and why
- Phase 0 stats grid
- Three CTAs (start with the why → browse blog → GitHub)

Visual style matches existing branded pages (404, newsletter landing): three-voice typography, four-color logo stripe, Virgil annotation, pull-quote.

### `/pricing/`

- Two-tier grid: Open source (AGPL-3.0, free) vs Commercial ("talk to us")
- Honest about why commercial pricing isn't public yet (sole-maintainer, deliberate design)
- Sketches the eventual pricing structure (perpetual product licence / org annual / OEM / founder pricing) so commercial buyers know what to expect
- Pre-filled mailto CTA

## Footer wiring

All four main pages (homepage, blog index, why-kronroe, docs) updated. Company column now reads:

  About → Pricing → Contact → Privacy → Cookie preferences

CLA moved to Developers column. "Commercial Licence" footer link removed (lives on /pricing/ now).

## Infrastructure

- `deploy-site.yml`: copies `site/about/`, `site/privacy/`, `site/pricing/` into `dist`
- `site/scripts/build-sitemap.py`: 3 new entries in `STATIC_PAGES`
- `site/public/sitemap.xml`: regenerated → 7 URLs (4 → 7)

## Test plan

- [x] All 9 Playwright consent tests pass after footer changes
- [x] `python3 site/scripts/build-sitemap.py --check` passes
- [x] Visually verified all three pages render with consent banner intact and proper typography
- [x] Asset sanity check from PR #181 will catch any missing-asset issues at deploy time
- [ ] Post-merge: re-submit sitemap on GSC + Bing (will pick up the 3 new URLs)
- [ ] Post-merge: spot-check `/privacy/#cookies` anchor lands at the right section

## Reviewer notes

- Privacy policy text is my best-effort drafting based on UK ICO guidance; if you want a lawyer to review it for £100-200 before publishing, that's reasonable for peace of mind. The structure and substantive points should be solid; specific phrasing might benefit from a legal once-over.
- Pricing page deliberately doesn't quote numbers. When you do publish numbers later, that's a small content-only PR.
- About page makes specific claims ("six target platforms", "Phase 0 — public alpha"). If those change, update the page accordingly.
