### PR TITLE
OG cards on /privacy/ + /pricing/, 404 footer cross-links

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -203,7 +203,15 @@
 </div>
 
 <footer>
-  <p>&copy; 2026 Kronroe &middot; <a href="https://github.com/kronroe/kronroe">GitHub</a></p>
+  <p>
+    &copy; 2026 Rebekah Cole &middot;
+    <a href="/">Home</a> &middot;
+    <a href="/blog/">Blog</a> &middot;
+    <a href="/docs/">Docs</a> &middot;
+    <a href="/about/">About</a> &middot;
+    <a href="/privacy/">Privacy</a> &middot;
+    <a href="https://github.com/kronroe/kronroe">GitHub</a>
+  </p>
 </footer>
 
 </body>

--- a/site/pricing/index.html
+++ b/site/pricing/index.html
@@ -8,8 +8,12 @@
 <title>Pricing — Kronroe</title>
 <meta name="description" content="Kronroe is dual-licensed under AGPL-3.0 and a commercial licence. Commercial pricing is in development — get in touch for early conversations."/>
 <meta property="og:title" content="Pricing — Kronroe"/>
+<meta property="og:description" content="Kronroe is dual-licensed under AGPL-3.0 and a commercial licence. Commercial pricing is in development — get in touch for early conversations."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://kronroe.dev/pricing/"/>
+<meta property="og:image" content="https://kronroe.dev/og-image.png"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="https://kronroe.dev/og-image.png"/>
 <link rel="canonical" href="https://kronroe.dev/pricing/"/>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script defer src="/js/analytics-consent.js"></script>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -8,8 +8,12 @@
 <title>Privacy &amp; Cookies | Kronroe</title>
 <meta name="description" content="How Kronroe handles personal data, cookies, and analytics. Plain-English version, with the legally precise version where it matters."/>
 <meta property="og:title" content="Privacy &amp; Cookies | Kronroe"/>
+<meta property="og:description" content="How Kronroe handles personal data, cookies, and analytics. Plain-English version, with the legally precise version where it matters."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://kronroe.dev/privacy/"/>
+<meta property="og:image" content="https://kronroe.dev/og-image.png"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="https://kronroe.dev/og-image.png"/>
 <link rel="canonical" href="https://kronroe.dev/privacy/"/>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script defer src="/js/analytics-consent.js"></script>


### PR DESCRIPTION
Three small consistency fixes following #183.

## What

- **/privacy/** + **/pricing/** gain `og:description`, `og:image`, `twitter:card`, and `twitter:image` so LinkedIn/Twitter/Slack/Bluesky previews of those URLs render with proper page-specific descriptions instead of generic "Kronroe" card text. Uses the site's main `og-image.png` as fallback.
- **404 page footer** now matches the richer pattern from /about/ /privacy/ /pricing/ — links to Home / Blog / Docs / About / Privacy / GitHub. The 404 is high-discoverability (any broken link on the site lands here) so it should help users find their way, not dead-end them.

## Test plan

- [x] All 9 Playwright consent tests pass
- [x] `python3 site/scripts/build-sitemap.py --check` passes
- [ ] Post-merge: paste `https://kronroe.dev/privacy/` into LinkedIn share preview, confirm it renders with description + image
- [ ] Post-merge: visit a typo'd URL on production, confirm 404 page footer has all the right links

