### PR TITLE
fix(docs): YAML-quote frontmatter values in /docs/<path>/index.md

### DIFF
--- a/site/scripts/build-docs.py
+++ b/site/scripts/build-docs.py
@@ -413,19 +413,41 @@ def render_llms_full_txt(docs_flat: list[Doc]) -> str:
     return "".join(parts).strip() + "\n"
 
 
+def yaml_quote(value: str) -> str:
+    """Wrap a string in YAML double-quotes with `"` and `\\` escaped.
+
+    Required for any frontmatter value that might contain a colon
+    (`Quick Start: Rust` is the canonical case in our corpus), `#`,
+    `&`, `*`, `!`, `|`, `>`, leading whitespace, or other YAML-special
+    characters. Quoting unconditionally is safer than trying to detect
+    "is this string ambiguous to a YAML parser?" — that's a long list
+    that grows over time as new fields get added.
+
+    YAML's double-quoted form recognises `\\"` and `\\\\` escape
+    sequences; we escape both to preserve the original string verbatim.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def render_doc_md_companion(doc: Doc) -> str:
     """Return the markdown bytes to write at /docs/<path>/index.md.
 
     Includes a small frontmatter-style preamble identifying the doc,
     then the original markdown source unchanged. Frontmatter helps
     agents parse without having to infer metadata from the body.
+
+    All values are YAML-quoted because doc titles routinely contain
+    characters that are YAML-special (notably `:` in titles like
+    "Quick Start: Rust") — unquoted, those produce invalid YAML that
+    parsers either reject or misinterpret.
     """
     preamble = (
         f"---\n"
-        f"title: {doc.title}\n"
-        f"category: {doc.category_title}\n"
-        f"url: https://kronroe.dev{doc.url}\n"
-        f"format: markdown\n"
+        f"title: {yaml_quote(doc.title)}\n"
+        f"category: {yaml_quote(doc.category_title)}\n"
+        f"url: {yaml_quote(f'https://kronroe.dev{doc.url}')}\n"
+        f"format: {yaml_quote('markdown')}\n"
         f"---\n\n"
     )
     return preamble + doc.body_md


### PR DESCRIPTION
## Summary

Follow-up fix to PR #186 (Phase 2 agent-readable formats), found during a post-merge audit.

## The bug

The `.md` companion files emitted at `/docs/<path>/index.md` had a YAML frontmatter preamble for agents to parse — but **the values weren't quoted**, so any doc with a colon in its title produced invalid YAML.

3 of 9 docs were affected:

```yaml
---
title: Quick Start: Rust       # ← invalid: YAML reads `: ` as key/value separator
category: Getting Started
url: https://kronroe.dev/docs/getting-started/quick-start-rust/
format: markdown
---
```

PyYAML's `safe_load()` errors on this. Agents that fetch the `.md` companion to parse frontmatter (the whole point of having it) either get a parse error or — depending on parser — silently malformed data.

## The fix

Introduce a `yaml_quote()` helper that wraps any string value in YAML double-quotes with `"` and `\\` properly escaped. Apply unconditionally to all frontmatter values.

### Why quote unconditionally instead of detecting "is this YAML-special?"

The list of YAML-special characters is long (`:`, `#`, `&`, `*`, `!`, `|`, `>`, leading whitespace, leading `[`/`{`, …) and grows when new YAML versions add tokens. Detection-based code drifts; quoting-unconditionally is the obviously-correct shape that won't bit-rot.

### Output after the fix

```yaml
---
title: "Quick Start: Rust"
category: "Getting Started"
url: "https://kronroe.dev/docs/getting-started/quick-start-rust/"
format: "markdown"
---
```

## Verification

PyYAML round-trip across all 9 generated `.md` companions:

```
✓ site/docs-built/getting-started/quick-start-mcp/index.md     → title='Quick Start: MCP Server'
✓ site/docs-built/getting-started/quick-start-python/index.md  → title='Quick Start: Python'
✓ site/docs-built/getting-started/quick-start-rust/index.md    → title='Quick Start: Rust'
Result: 9 ok, 0 fail
```

The colon survives the round-trip intact.

## Test plan

- [x] All 9 `.md` companions parse cleanly with PyYAML (verified locally before push)
- [x] Three colon-containing titles round-trip correctly (`Quick Start: Rust` etc.)
- [ ] Post-merge: `curl https://kronroe.dev/docs/getting-started/quick-start-rust/index.md` → frontmatter values are double-quoted

## Reviewer notes

Found via the audit prompted before merging the original PR #186. The audit also flagged two other items:
- JSON-LD `description` field literally includes `...` truncation marker (cosmetic, not blocking)
- `llms-full.txt` includes raw HTML from docs that use it (e.g. tab markup) — acceptable, agents that want clean text can fetch individual `.md` companions

Both deferred to Phase 3b.
